### PR TITLE
feat: add app:tui shell command with mode detection and status bar (#28)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "symfony/psr-http-message-bridge": "8.1.*",
         "symfony/runtime": "8.1.*",
         "symfony/scheduler": "8.1.*",
+        "symfony/tui": "8.1.*",
         "symfony/yaml": "8.1.*"
     },
     "config": {
@@ -82,7 +83,6 @@
         "phpstan/phpstan-symfony": "^2.0.18",
         "phpunit/phpunit": "^11.5.55",
         "symfony/browser-kit": "8.1.*",
-        "symfony/css-selector": "8.1.*",
-        "symfony/tui": "8.1.*"
+        "symfony/css-selector": "8.1.*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "44eecfc06064fa84b2e705598001ae29",
+    "content-hash": "f91b66d70525e4f0d1c0e45ac58fd1ea",
     "packages": [
         {
             "name": "devizzent/cebe-php-openapi",
@@ -1149,6 +1149,78 @@
                 "source": "https://github.com/Respect/Validation/tree/2.4.12"
             },
             "time": "2026-02-08T00:13:50+00:00"
+        },
+        {
+            "name": "revolt/event-loop",
+            "version": "v1.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/revoltphp/event-loop.git",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/44061cf513e53c6200372fc935ac42271566295d",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Revolt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Rock-solid event loop for concurrent PHP applications.",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrency",
+                "event",
+                "event-loop",
+                "non-blocking",
+                "scheduler"
+            ],
+            "support": {
+                "issues": "https://github.com/revoltphp/event-loop/issues",
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.9"
+            },
+            "time": "2026-05-16T17:55:38+00:00"
         },
         {
             "name": "riverline/multipart-parser",
@@ -3603,6 +3675,84 @@
             "time": "2026-05-13T12:23:03+00:00"
         },
         {
+            "name": "symfony/tui",
+            "version": "v8.1.0-BETA3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/tui.git",
+                "reference": "f9999025c27d3fa03106e5f7187181126e5bdd2c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/tui/zipball/f9999025c27d3fa03106e5f7187181126e5bdd2c",
+                "reference": "f9999025c27d3fa03106e5f7187181126e5bdd2c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "revolt/event-loop": "^1.0",
+                "symfony/event-dispatcher": "^8.0",
+                "symfony/string": "^8.0"
+            },
+            "require-dev": {
+                "league/commonmark": "^2.9",
+                "tempest/highlight": "^2.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Tui\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a terminal UI framework for building rich, interactive CLI applications in PHP",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "console",
+                "terminal",
+                "tui"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/tui/tree/v8.1.0-BETA3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-19T20:20:07+00:00"
+        },
+        {
             "name": "symfony/var-dumper",
             "version": "v8.1.0-BETA1",
             "source": {
@@ -5930,78 +6080,6 @@
             "time": "2024-06-11T12:45:25+00:00"
         },
         {
-            "name": "revolt/event-loop",
-            "version": "v1.0.9",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/revoltphp/event-loop.git",
-                "reference": "44061cf513e53c6200372fc935ac42271566295d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/44061cf513e53c6200372fc935ac42271566295d",
-                "reference": "44061cf513e53c6200372fc935ac42271566295d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "jetbrains/phpstorm-stubs": "^2019.3",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "6.16.*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Revolt\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                },
-                {
-                    "name": "Cees-Jan Kiewiet",
-                    "email": "ceesjank@gmail.com"
-                },
-                {
-                    "name": "Christian Lück",
-                    "email": "christian@clue.engineering"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                }
-            ],
-            "description": "Rock-solid event loop for concurrent PHP applications.",
-            "keywords": [
-                "async",
-                "asynchronous",
-                "concurrency",
-                "event",
-                "event-loop",
-                "non-blocking",
-                "scheduler"
-            ],
-            "support": {
-                "issues": "https://github.com/revoltphp/event-loop/issues",
-                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.9"
-            },
-            "time": "2026-05-16T17:55:38+00:00"
-        },
-        {
             "name": "sebastian/cli-parser",
             "version": "3.0.2",
             "source": {
@@ -7453,84 +7531,6 @@
                 }
             ],
             "time": "2026-04-18T13:52:23+00:00"
-        },
-        {
-            "name": "symfony/tui",
-            "version": "v8.1.0-BETA3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/tui.git",
-                "reference": "f9999025c27d3fa03106e5f7187181126e5bdd2c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/tui/zipball/f9999025c27d3fa03106e5f7187181126e5bdd2c",
-                "reference": "f9999025c27d3fa03106e5f7187181126e5bdd2c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4.1",
-                "revolt/event-loop": "^1.0",
-                "symfony/event-dispatcher": "^8.0",
-                "symfony/string": "^8.0"
-            },
-            "require-dev": {
-                "league/commonmark": "^2.9",
-                "tempest/highlight": "^2.16"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Tui\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides a terminal UI framework for building rich, interactive CLI applications in PHP",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "cli",
-                "console",
-                "terminal",
-                "tui"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/tui/tree/v8.1.0-BETA3"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-19T20:20:07+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -43,8 +43,8 @@ final class TuiCommand extends Command
         $tui->add($this->buildMainMenuWidget($mode));
         $tui->add($this->buildStatusBarWidget($mode, $reachabilityResult));
 
-        // Listen at the Tui level (before focus routing) so Q quits regardless
-        // of which sub-panel later tickets give focus to.
+        // Registered on the Tui (not on a widget) so Q quits before focus
+        // routing, regardless of which sub-panel currently has focus.
         $tui->addListener(static function (InputEvent $event) use ($tui): void {
             $rawInput = $event->getData();
             if ('q' === $rawInput || 'Q' === $rawInput) {

--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -19,9 +19,8 @@ use Symfony\Component\Tui\Widget\AbstractWidget;
 use Symfony\Component\Tui\Widget\ContainerWidget;
 use Symfony\Component\Tui\Widget\SelectListWidget;
 use Symfony\Component\Tui\Widget\TextWidget;
-use Symfony\Component\Tui\Widget\Util\StringUtils;
 
-#[AsCommand(name: 'app:tui', description: 'Launches the PixelCast unified terminal interface.')]
+#[AsCommand(name: 'app:tui', description: 'Opens the PixelCast unified terminal interface')]
 final class TuiCommand extends Command
 {
     public function __construct(
@@ -92,8 +91,9 @@ final class TuiCommand extends Command
             return 'n/a';
         }
 
-        // The URL is sourced from an env var (untrusted by contract) and
-        // TextWidget renders its content verbatim including ANSI escapes.
-        return StringUtils::stripControlBytes($baseUrl);
+        // The URL comes from an env var and TextWidget renders content
+        // verbatim including ANSI escapes, so we strip C0/C1 controls and
+        // DEL to prevent terminal-escape injection.
+        return preg_replace("/[\x00-\x08\x0b-\x1f\x7f]|\xc2[\x80-\x9f]/", '', $baseUrl) ?? '';
     }
 }

--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Tui\Menu\TuiMenuFactory;
+use App\Tui\Reachability\DeviceReachabilityProbe;
+use App\Tui\Reachability\DeviceReachabilityResult;
+use App\Tui\TuiMode;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Tui\Event\InputEvent;
+use Symfony\Component\Tui\Tui;
+use Symfony\Component\Tui\Widget\AbstractWidget;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\SelectListWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+use Symfony\Component\Tui\Widget\Util\StringUtils;
+
+#[AsCommand(name: 'app:tui', description: 'Launches the PixelCast unified terminal interface.')]
+final class TuiCommand extends Command
+{
+    public function __construct(
+        #[Autowire('%kernel.environment%')]
+        private readonly string $appEnvironment,
+        #[Autowire('%env(default::PIXELCAST_DEVICE_BASE_URL)%')]
+        private readonly ?string $deviceBaseUrl,
+        private readonly DeviceReachabilityProbe $deviceReachabilityProbe,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $mode = TuiMode::fromAppEnvironment($this->appEnvironment);
+        $reachabilityResult = $this->deviceReachabilityProbe->probe($this->deviceBaseUrl);
+
+        $tui = new Tui();
+        $tui->add($this->buildMainMenuWidget($mode));
+        $tui->add($this->buildStatusBarWidget($mode, $reachabilityResult));
+
+        // Listen at the Tui level (before focus routing) so Q quits regardless
+        // of which sub-panel later tickets give focus to.
+        $tui->addListener(static function (InputEvent $event) use ($tui): void {
+            $rawInput = $event->getData();
+            if ('q' === $rawInput || 'Q' === $rawInput) {
+                $event->stopPropagation();
+                $tui->stop();
+            }
+        });
+
+        $tui->run();
+
+        return Command::SUCCESS;
+    }
+
+    private function buildMainMenuWidget(TuiMode $mode): AbstractWidget
+    {
+        $menuItems = TuiMenuFactory::buildForMode($mode);
+        $selectListItems = TuiMenuFactory::toSelectListItems($menuItems);
+
+        $selectList = new SelectListWidget($selectListItems, maxVisible: \count($selectListItems));
+
+        $mainPanel = new ContainerWidget();
+        $mainPanel->expandVertically(true);
+        $mainPanel->add($selectList);
+
+        return $mainPanel;
+    }
+
+    private function buildStatusBarWidget(TuiMode $mode, DeviceReachabilityResult $reachabilityResult): AbstractWidget
+    {
+        $targetLabel = $this->formatTargetLabel($this->deviceBaseUrl);
+
+        $statusLine = \sprintf(
+            'MODE: %s   TARGET: %s (%s)   [Q] quit',
+            $mode->displayLabel(),
+            $targetLabel,
+            $reachabilityResult->displayLabel,
+        );
+
+        return new TextWidget($statusLine);
+    }
+
+    private function formatTargetLabel(?string $baseUrl): string
+    {
+        if (null === $baseUrl || '' === $baseUrl) {
+            return 'n/a';
+        }
+
+        // The URL is sourced from an env var (untrusted by contract) and
+        // TextWidget renders its content verbatim including ANSI escapes.
+        return StringUtils::stripControlBytes($baseUrl);
+    }
+}

--- a/src/Tui/Menu/TuiMenuFactory.php
+++ b/src/Tui/Menu/TuiMenuFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Menu;
+
+use App\Tui\TuiMode;
+
+final class TuiMenuFactory
+{
+    /**
+     * @return list<TuiMenuItem>
+     */
+    public static function buildForMode(TuiMode $mode): array
+    {
+        $sharedScenariosItem = new TuiMenuItem('1', 'Scenarios', 'scenarios');
+
+        if (TuiMode::Dev === $mode) {
+            return [
+                $sharedScenariosItem,
+                new TuiMenuItem('2', 'Sync Now', 'sync-now'),
+                new TuiMenuItem('3', 'Request Log', 'request-log'),
+                new TuiMenuItem('4', 'Reset Sim', 'reset-sim'),
+            ];
+        }
+
+        return [
+            $sharedScenariosItem,
+            new TuiMenuItem('2', 'Configuration', 'configuration'),
+            new TuiMenuItem('3', 'Device Status', 'device-status'),
+        ];
+    }
+
+    /**
+     * @param list<TuiMenuItem> $menuItems
+     *
+     * @return list<array{value: string, label: string}>
+     */
+    public static function toSelectListItems(array $menuItems): array
+    {
+        $selectListItems = [];
+        foreach ($menuItems as $menuItem) {
+            $selectListItems[] = [
+                'value' => $menuItem->value,
+                'label' => \sprintf('[%s] %s', $menuItem->shortcut, $menuItem->label),
+            ];
+        }
+
+        return $selectListItems;
+    }
+}

--- a/src/Tui/Menu/TuiMenuItem.php
+++ b/src/Tui/Menu/TuiMenuItem.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Menu;
+
+final readonly class TuiMenuItem
+{
+    public function __construct(
+        public string $shortcut,
+        public string $label,
+        public string $value,
+    ) {
+    }
+}

--- a/src/Tui/Reachability/DeviceReachabilityProbe.php
+++ b/src/Tui/Reachability/DeviceReachabilityProbe.php
@@ -22,8 +22,13 @@ final class DeviceReachabilityProbe
             return DeviceReachabilityResult::fromStatus(DeviceReachabilityStatus::Unknown);
         }
 
+        $scheme = $parsedUrl['scheme'] ?? '';
+        if ('http' !== $scheme && 'https' !== $scheme) {
+            return DeviceReachabilityResult::fromStatus(DeviceReachabilityStatus::Unknown);
+        }
+
         $host = $parsedUrl['host'];
-        $port = $parsedUrl['port'] ?? ('https' === ($parsedUrl['scheme'] ?? '') ? 443 : 80);
+        $port = $parsedUrl['port'] ?? ('https' === $scheme ? 443 : 80);
 
         $errorNumber = 0;
         $errorMessage = '';

--- a/src/Tui/Reachability/DeviceReachabilityProbe.php
+++ b/src/Tui/Reachability/DeviceReachabilityProbe.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Reachability;
+
+final class DeviceReachabilityProbe
+{
+    public function __construct(
+        private readonly float $timeoutSeconds = 0.5,
+    ) {
+    }
+
+    public function probe(?string $baseUrl): DeviceReachabilityResult
+    {
+        if (null === $baseUrl || '' === $baseUrl) {
+            return DeviceReachabilityResult::fromStatus(DeviceReachabilityStatus::Unknown);
+        }
+
+        $parsedUrl = parse_url($baseUrl);
+        if (false === $parsedUrl || !isset($parsedUrl['host']) || '' === $parsedUrl['host']) {
+            return DeviceReachabilityResult::fromStatus(DeviceReachabilityStatus::Unknown);
+        }
+
+        $host = $parsedUrl['host'];
+        $port = $parsedUrl['port'] ?? ('https' === ($parsedUrl['scheme'] ?? '') ? 443 : 80);
+
+        $errorNumber = 0;
+        $errorMessage = '';
+
+        // stream_socket_client emits a warning on connection failure; swap the
+        // error handler instead of relying on @ so PHPStan strict rules stay happy.
+        set_error_handler(static fn (): bool => true);
+        try {
+            $connection = stream_socket_client(
+                \sprintf('tcp://%s:%d', $host, $port),
+                $errorNumber,
+                $errorMessage,
+                $this->timeoutSeconds,
+                \STREAM_CLIENT_CONNECT,
+            );
+        } finally {
+            restore_error_handler();
+        }
+
+        if (false === $connection) {
+            return DeviceReachabilityResult::fromStatus(DeviceReachabilityStatus::Unreachable);
+        }
+
+        fclose($connection);
+
+        return DeviceReachabilityResult::fromStatus(DeviceReachabilityStatus::Reachable);
+    }
+}

--- a/src/Tui/Reachability/DeviceReachabilityProbe.php
+++ b/src/Tui/Reachability/DeviceReachabilityProbe.php
@@ -28,8 +28,8 @@ final class DeviceReachabilityProbe
         $errorNumber = 0;
         $errorMessage = '';
 
-        // stream_socket_client emits a warning on connection failure; swap the
-        // error handler instead of relying on @ so PHPStan strict rules stay happy.
+        // stream_socket_client emits a PHP warning on connection failure; we
+        // discard it because $errorNumber/$errorMessage already carry the cause.
         set_error_handler(static fn (): bool => true);
         try {
             $connection = stream_socket_client(

--- a/src/Tui/Reachability/DeviceReachabilityResult.php
+++ b/src/Tui/Reachability/DeviceReachabilityResult.php
@@ -22,9 +22,4 @@ final readonly class DeviceReachabilityResult
 
         return new self($status, $defaultLabel);
     }
-
-    public static function withCustomLabel(DeviceReachabilityStatus $status, string $displayLabel): self
-    {
-        return new self($status, $displayLabel);
-    }
 }

--- a/src/Tui/Reachability/DeviceReachabilityResult.php
+++ b/src/Tui/Reachability/DeviceReachabilityResult.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Reachability;
+
+final readonly class DeviceReachabilityResult
+{
+    public function __construct(
+        public DeviceReachabilityStatus $status,
+        public string $displayLabel,
+    ) {
+    }
+
+    public static function fromStatus(DeviceReachabilityStatus $status): self
+    {
+        $defaultLabel = match ($status) {
+            DeviceReachabilityStatus::Reachable => 'Reachable',
+            DeviceReachabilityStatus::Unreachable => 'Unreachable',
+            DeviceReachabilityStatus::Unknown => 'Unknown',
+        };
+
+        return new self($status, $defaultLabel);
+    }
+
+    public static function withCustomLabel(DeviceReachabilityStatus $status, string $displayLabel): self
+    {
+        return new self($status, $displayLabel);
+    }
+}

--- a/src/Tui/Reachability/DeviceReachabilityStatus.php
+++ b/src/Tui/Reachability/DeviceReachabilityStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Reachability;
+
+enum DeviceReachabilityStatus: string
+{
+    case Reachable = 'reachable';
+    case Unreachable = 'unreachable';
+    case Unknown = 'unknown';
+}

--- a/src/Tui/TuiMode.php
+++ b/src/Tui/TuiMode.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui;
+
+enum TuiMode: string
+{
+    case Dev = 'dev';
+    case Prod = 'prod';
+
+    public static function fromAppEnvironment(string $appEnvironment): self
+    {
+        return 'dev' === $appEnvironment ? self::Dev : self::Prod;
+    }
+
+    public function displayLabel(): string
+    {
+        return self::Dev === $this ? 'DEV' : 'PROD';
+    }
+}

--- a/tests/Tui/Menu/TuiMenuFactoryTest.php
+++ b/tests/Tui/Menu/TuiMenuFactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Menu;
+
+use App\Tui\Menu\TuiMenuFactory;
+use App\Tui\Menu\TuiMenuItem;
+use App\Tui\TuiMode;
+use PHPUnit\Framework\TestCase;
+
+final class TuiMenuFactoryTest extends TestCase
+{
+    public function testBuildForDevModeProducesFourItemsWithExpectedLabels(): void
+    {
+        $items = TuiMenuFactory::buildForMode(TuiMode::Dev);
+
+        self::assertCount(4, $items);
+        self::assertSame(
+            ['1', '2', '3', '4'],
+            array_map(static fn (TuiMenuItem $item): string => $item->shortcut, $items),
+        );
+        self::assertSame(
+            ['Scenarios', 'Sync Now', 'Request Log', 'Reset Sim'],
+            array_map(static fn (TuiMenuItem $item): string => $item->label, $items),
+        );
+        self::assertSame(
+            ['scenarios', 'sync-now', 'request-log', 'reset-sim'],
+            array_map(static fn (TuiMenuItem $item): string => $item->value, $items),
+        );
+    }
+
+    public function testBuildForProdModeProducesThreeItemsWithExpectedLabels(): void
+    {
+        $items = TuiMenuFactory::buildForMode(TuiMode::Prod);
+
+        self::assertCount(3, $items);
+        self::assertSame(
+            ['1', '2', '3'],
+            array_map(static fn (TuiMenuItem $item): string => $item->shortcut, $items),
+        );
+        self::assertSame(
+            ['Scenarios', 'Configuration', 'Device Status'],
+            array_map(static fn (TuiMenuItem $item): string => $item->label, $items),
+        );
+        self::assertSame(
+            ['scenarios', 'configuration', 'device-status'],
+            array_map(static fn (TuiMenuItem $item): string => $item->value, $items),
+        );
+    }
+
+    public function testToSelectListItemsFormatsLabelWithShortcut(): void
+    {
+        $items = TuiMenuFactory::buildForMode(TuiMode::Dev);
+
+        $selectListItems = TuiMenuFactory::toSelectListItems($items);
+
+        self::assertSame(
+            [
+                ['value' => 'scenarios', 'label' => '[1] Scenarios'],
+                ['value' => 'sync-now', 'label' => '[2] Sync Now'],
+                ['value' => 'request-log', 'label' => '[3] Request Log'],
+                ['value' => 'reset-sim', 'label' => '[4] Reset Sim'],
+            ],
+            $selectListItems,
+        );
+    }
+}

--- a/tests/Tui/Reachability/DeviceReachabilityProbeTest.php
+++ b/tests/Tui/Reachability/DeviceReachabilityProbeTest.php
@@ -43,13 +43,21 @@ final class DeviceReachabilityProbeTest extends TestCase
     {
         $probe = new DeviceReachabilityProbe();
 
-        // TEST-NET-1 (RFC 5737): 192.0.2.0/24 is reserved for documentation and
-        // is guaranteed not to route, so the connect attempt always fails fast
-        // within the default 0.5s timeout regardless of the runner's network.
-        $result = $probe->probe('http://192.0.2.1:80');
+        // 127.0.0.1:1 yields ECONNREFUSED immediately and independently of
+        // the runner's network because no standard service binds tcpmux.
+        $result = $probe->probe('http://127.0.0.1:1');
 
         self::assertSame(DeviceReachabilityStatus::Unreachable, $result->status);
         self::assertSame('Unreachable', $result->displayLabel);
+    }
+
+    public function testProbeWithUnsupportedSchemeReturnsUnknown(): void
+    {
+        $probe = new DeviceReachabilityProbe();
+
+        $result = $probe->probe('redis://localhost:6379');
+
+        self::assertSame(DeviceReachabilityStatus::Unknown, $result->status);
     }
 
     public function testDefaultDisplayLabelsMatchEachStatus(): void

--- a/tests/Tui/Reachability/DeviceReachabilityProbeTest.php
+++ b/tests/Tui/Reachability/DeviceReachabilityProbeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Reachability;
+
+use App\Tui\Reachability\DeviceReachabilityProbe;
+use App\Tui\Reachability\DeviceReachabilityResult;
+use App\Tui\Reachability\DeviceReachabilityStatus;
+use PHPUnit\Framework\TestCase;
+
+final class DeviceReachabilityProbeTest extends TestCase
+{
+    public function testProbeWithNullBaseUrlReturnsUnknown(): void
+    {
+        $probe = new DeviceReachabilityProbe();
+
+        $result = $probe->probe(null);
+
+        self::assertSame(DeviceReachabilityStatus::Unknown, $result->status);
+        self::assertSame('Unknown', $result->displayLabel);
+    }
+
+    public function testProbeWithEmptyBaseUrlReturnsUnknown(): void
+    {
+        $probe = new DeviceReachabilityProbe();
+
+        $result = $probe->probe('');
+
+        self::assertSame(DeviceReachabilityStatus::Unknown, $result->status);
+    }
+
+    public function testProbeWithMalformedUrlReturnsUnknown(): void
+    {
+        $probe = new DeviceReachabilityProbe();
+
+        $result = $probe->probe('not a url');
+
+        self::assertSame(DeviceReachabilityStatus::Unknown, $result->status);
+    }
+
+    public function testProbeWithUnreachableHostReturnsUnreachable(): void
+    {
+        $probe = new DeviceReachabilityProbe();
+
+        // TEST-NET-1 (RFC 5737): 192.0.2.0/24 is reserved for documentation and
+        // is guaranteed not to route, so the connect attempt always fails fast
+        // within the default 0.5s timeout regardless of the runner's network.
+        $result = $probe->probe('http://192.0.2.1:80');
+
+        self::assertSame(DeviceReachabilityStatus::Unreachable, $result->status);
+        self::assertSame('Unreachable', $result->displayLabel);
+    }
+
+    public function testDefaultDisplayLabelsMatchEachStatus(): void
+    {
+        $expectedLabels = [
+            DeviceReachabilityStatus::Reachable->value => 'Reachable',
+            DeviceReachabilityStatus::Unreachable->value => 'Unreachable',
+            DeviceReachabilityStatus::Unknown->value => 'Unknown',
+        ];
+
+        foreach (DeviceReachabilityStatus::cases() as $status) {
+            $result = DeviceReachabilityResult::fromStatus($status);
+
+            self::assertSame($status, $result->status);
+            self::assertSame($expectedLabels[$status->value], $result->displayLabel);
+        }
+    }
+}

--- a/tests/Tui/TuiModeTest.php
+++ b/tests/Tui/TuiModeTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui;
+
+use App\Tui\TuiMode;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class TuiModeTest extends TestCase
+{
+    public function testFromAppEnvironmentReturnsDevForLiteralDevValue(): void
+    {
+        self::assertSame(TuiMode::Dev, TuiMode::fromAppEnvironment('dev'));
+    }
+
+    #[DataProvider('nonDevEnvironmentProvider')]
+    public function testFromAppEnvironmentReturnsProdForNonDevValues(string $appEnvironment): void
+    {
+        self::assertSame(TuiMode::Prod, TuiMode::fromAppEnvironment($appEnvironment));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function nonDevEnvironmentProvider(): iterable
+    {
+        yield 'literal prod' => ['prod'];
+        yield 'literal test' => ['test'];
+        yield 'literal staging' => ['staging'];
+        yield 'empty string' => [''];
+        yield 'uppercase DEV (case-sensitive)' => ['DEV'];
+        yield 'longer development word' => ['development'];
+    }
+
+    public function testDisplayLabel(): void
+    {
+        self::assertSame('DEV', TuiMode::Dev->displayLabel());
+        self::assertSame('PROD', TuiMode::Prod->displayLabel());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the `app:tui` Symfony console command using `symfony/tui`. Builds a full-screen vertical layout: a `SelectListWidget` main menu panel that expands to fill the screen, plus a fixed `TextWidget` status bar pinned at the bottom showing mode, target URL and reachability state.
- Menu items adapt to `APP_ENV`: `dev` exposes `[2] Sync Now / [3] Request Log / [4] Reset Sim`, anything else falls back to prod (`[2] Configuration / [3] Device Status`). `Q` quits cleanly; the terminal is always restored.
- Introduces a pure domain layer (`App\Tui\*`) that is unit-tested in isolation (48 tests / 121 assertions) so the command stays a thin orchestrator. `DeviceReachabilityProbe` uses a 0.5s `stream_socket_client` probe restricted to http/https; unsupported schemes return `Unknown`.

## Known follow-ups (deferred per #28 scope)

- The global `q`/`Q` listener intercepts before focus routing — fine for the placeholder menu, but a future ticket adding an `InputWidget` (search, filter, etc.) will need to skip the shortcut when an input has the focus.
- The reachability probe is synchronous and can block startup by up to 500 ms before the first render; a future ticket can move it to an async tick listener.

## Test plan

- [x] `make test` — 48 tests, 121 assertions
- [x] `make cs-check` — clean
- [x] PHPStan (`--memory-limit=512M`) — no errors
- [ ] Manual: `make shell && php bin/console app:tui` — full-screen TUI, dev menu, `Q` quits cleanly
- [ ] Manual: `APP_ENV=prod php bin/console app:tui` — prod menu items visible
- [ ] Manual: `PIXELCAST_DEVICE_BASE_URL=http://127.0.0.1:1 php bin/console app:tui` — status bar shows `Unreachable`

Closes #28