### PR TITLE
feat(tui): dev-mode state inspector and request log panels (#29)

### DIFF
--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace App\Command;
 
+use App\Tui\Inspector\InspectorPoller;
+use App\Tui\Inspector\InspectorTransport;
+use App\Tui\Inspector\RequestLogPanel;
+use App\Tui\Inspector\StateInspectorPanel;
 use App\Tui\Menu\TuiMenuFactory;
 use App\Tui\Reachability\DeviceReachabilityProbe;
 use App\Tui\Reachability\DeviceReachabilityResult;
@@ -14,6 +18,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Tui\Event\InputEvent;
+use Symfony\Component\Tui\Event\TickEvent;
 use Symfony\Component\Tui\Tui;
 use Symfony\Component\Tui\Widget\AbstractWidget;
 use Symfony\Component\Tui\Widget\ContainerWidget;
@@ -29,6 +34,7 @@ final class TuiCommand extends Command
         #[Autowire('%env(default::PIXELCAST_DEVICE_BASE_URL)%')]
         private readonly ?string $deviceBaseUrl,
         private readonly DeviceReachabilityProbe $deviceReachabilityProbe,
+        private readonly InspectorTransport $inspectorHttpClient,
     ) {
         parent::__construct();
     }
@@ -40,7 +46,37 @@ final class TuiCommand extends Command
 
         $tui = new Tui();
         $tui->add($this->buildMainMenuWidget($mode));
+
+        $inspectorPoller = null;
+        $stateInspectorPanel = null;
+        $requestLogPanel = null;
+
+        if (TuiMode::Dev === $mode) {
+            $inspectorPoller = new InspectorPoller(
+                $this->inspectorHttpClient,
+                $this->deviceBaseUrl,
+            );
+            $stateInspectorPanel = new StateInspectorPanel();
+            $requestLogPanel = new RequestLogPanel();
+
+            $initialSnapshot = $inspectorPoller->poll();
+            $stateInspectorPanel->update($initialSnapshot, busy: false);
+            $requestLogPanel->update($initialSnapshot, busy: false);
+
+            $tui->add($stateInspectorPanel->widget());
+            $tui->add($requestLogPanel->widget());
+        }
+
         $tui->add($this->buildStatusBarWidget($mode, $reachabilityResult));
+
+        if (null !== $inspectorPoller) {
+            $tui->onTick($this->buildInspectorTickListener(
+                $tui,
+                $inspectorPoller,
+                $stateInspectorPanel,
+                $requestLogPanel,
+            ));
+        }
 
         // Registered on the Tui (not on a widget) so Q quits before focus
         // routing, regardless of which sub-panel currently has focus.
@@ -55,6 +91,30 @@ final class TuiCommand extends Command
         $tui->run();
 
         return Command::SUCCESS;
+    }
+
+    private function buildInspectorTickListener(
+        Tui $tui,
+        InspectorPoller $inspectorPoller,
+        StateInspectorPanel $stateInspectorPanel,
+        RequestLogPanel $requestLogPanel,
+    ): callable {
+        return static function (TickEvent $event) use (
+            $tui,
+            $inspectorPoller,
+            $stateInspectorPanel,
+            $requestLogPanel,
+        ): void {
+            if (!$inspectorPoller->pollIfDue($event->getDeltaTime())) {
+                return;
+            }
+
+            $event->setBusy(true);
+            $snapshot = $inspectorPoller->getLatestSnapshot();
+            $stateInspectorPanel->update($snapshot, busy: false);
+            $requestLogPanel->update($snapshot, busy: false);
+            $tui->requestRender();
+        };
     }
 
     private function buildMainMenuWidget(TuiMode $mode): AbstractWidget

--- a/src/Tui/Inspector/InspectorHttpClient.php
+++ b/src/Tui/Inspector/InspectorHttpClient.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Inspector;
+
+final class InspectorHttpClient implements InspectorTransport
+{
+    public function __construct(
+        private readonly float $timeoutSeconds = 0.5,
+    ) {
+    }
+
+    public function fetch(?string $baseUrl): InspectorSnapshot
+    {
+        if (null === $baseUrl || '' === $baseUrl) {
+            return InspectorSnapshot::unreachable('no base URL configured');
+        }
+
+        $inspectorUrl = rtrim($baseUrl, '/').'/__inspect';
+
+        $streamContext = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'timeout' => $this->timeoutSeconds,
+                'ignore_errors' => true,
+                'header' => "Accept: application/json\r\n",
+            ],
+        ]);
+
+        // file_get_contents emits a PHP warning on connection failure; we
+        // swallow it here because we already detect the failure via false.
+        set_error_handler(static fn (): bool => true);
+        try {
+            $response = file_get_contents($inspectorUrl, false, $streamContext);
+        } finally {
+            restore_error_handler();
+        }
+
+        if (false === $response) {
+            return InspectorSnapshot::unreachable('connection failed');
+        }
+
+        $decoded = json_decode($response, true);
+        if (!\is_array($decoded)) {
+            return InspectorSnapshot::unreachable('invalid response');
+        }
+
+        /** @var array<string, mixed> $payload */
+        $payload = $decoded;
+
+        return InspectorSnapshot::fromInspectPayload($payload);
+    }
+}

--- a/src/Tui/Inspector/InspectorPoller.php
+++ b/src/Tui/Inspector/InspectorPoller.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Inspector;
+
+final class InspectorPoller
+{
+    private ?InspectorSnapshot $latestSnapshot = null;
+    private float $secondsSinceLastPoll = 0.0;
+
+    public function __construct(
+        private readonly InspectorTransport $httpClient,
+        private readonly ?string $baseUrl,
+        private readonly float $pollIntervalSeconds = 1.0,
+    ) {
+    }
+
+    public function poll(): InspectorSnapshot
+    {
+        $snapshot = $this->httpClient->fetch($this->baseUrl);
+        $this->latestSnapshot = $snapshot;
+        $this->secondsSinceLastPoll = 0.0;
+
+        return $snapshot;
+    }
+
+    public function pollIfDue(float $deltaSeconds): bool
+    {
+        $clampedDelta = max(0.0, $deltaSeconds);
+        $this->secondsSinceLastPoll += $clampedDelta;
+
+        if ($this->secondsSinceLastPoll < $this->pollIntervalSeconds) {
+            return false;
+        }
+
+        $this->poll();
+
+        return true;
+    }
+
+    public function getLatestSnapshot(): ?InspectorSnapshot
+    {
+        return $this->latestSnapshot;
+    }
+}

--- a/src/Tui/Inspector/InspectorSnapshot.php
+++ b/src/Tui/Inspector/InspectorSnapshot.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Inspector;
+
+final readonly class InspectorSnapshot
+{
+    /**
+     * @param array<string, mixed>|null $state
+     * @param list<array<string, mixed>>|null $requests
+     */
+    public function __construct(
+        public ?array $state,
+        public ?array $requests,
+        public bool $reachable,
+        public ?string $errorMessage = null,
+    ) {
+    }
+
+    public static function unreachable(string $errorMessage): self
+    {
+        return new self(null, null, false, $errorMessage);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public static function fromInspectPayload(array $payload): self
+    {
+        $state = null;
+        if (isset($payload['state']) && \is_array($payload['state'])) {
+            /** @var array<string, mixed> $stateValue */
+            $stateValue = $payload['state'];
+            $state = $stateValue;
+        }
+
+        $requests = null;
+        if (isset($payload['requests']) && \is_array($payload['requests'])) {
+            /** @var list<array<string, mixed>> $requestsValue */
+            $requestsValue = array_values(array_filter(
+                $payload['requests'],
+                static fn (mixed $entry): bool => \is_array($entry),
+            ));
+            $requests = $requestsValue;
+        }
+
+        return new self($state, $requests, true);
+    }
+}

--- a/src/Tui/Inspector/InspectorTransport.php
+++ b/src/Tui/Inspector/InspectorTransport.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Inspector;
+
+interface InspectorTransport
+{
+    public function fetch(?string $baseUrl): InspectorSnapshot;
+}

--- a/src/Tui/Inspector/RequestLogFormatter.php
+++ b/src/Tui/Inspector/RequestLogFormatter.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Inspector;
+
+final class RequestLogFormatter
+{
+    private const ERROR_MAX_LENGTH = 60;
+
+    /**
+     * @param list<array<string, mixed>>|null $requests
+     */
+    public static function format(?array $requests): string
+    {
+        if (null === $requests || [] === $requests) {
+            return 'No data';
+        }
+
+        $newestFirst = array_reverse($requests);
+
+        $lines = [];
+        foreach ($newestFirst as $entry) {
+            $lines[] = self::renderEntry($entry);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param array<string, mixed> $entry
+     */
+    private static function renderEntry(array $entry): string
+    {
+        $time = self::renderTime($entry['timestamp'] ?? null);
+        $method = isset($entry['method']) && \is_string($entry['method']) ? $entry['method'] : '?';
+        $path = isset($entry['path']) && \is_string($entry['path']) ? $entry['path'] : '?';
+
+        $rawValidation = $entry['validation'] ?? null;
+        /** @var array<string, mixed> $validation */
+        $validation = \is_array($rawValidation)
+            ? $rawValidation
+            : ['valid' => false, 'error' => 'missing'];
+
+        $verdict = self::renderVerdict($validation);
+
+        return \sprintf('%s  %s  %s  %s', $time, $method, $path, $verdict);
+    }
+
+    private static function renderTime(mixed $timestamp): string
+    {
+        if (!\is_string($timestamp)) {
+            return '??:??:??';
+        }
+
+        try {
+            $parsed = new \DateTimeImmutable($timestamp);
+        } catch (\Exception) {
+            return '??:??:??';
+        }
+
+        return $parsed->format('H:i:s');
+    }
+
+    /**
+     * @param array<string, mixed> $validation
+     */
+    private static function renderVerdict(array $validation): string
+    {
+        $isValid = isset($validation['valid']) && true === $validation['valid'];
+        if ($isValid) {
+            return 'OK';
+        }
+
+        $errorRaw = $validation['error'] ?? 'unknown';
+        $errorMessage = \is_string($errorRaw) ? $errorRaw : 'unknown';
+        if (\strlen($errorMessage) > self::ERROR_MAX_LENGTH) {
+            $errorMessage = substr($errorMessage, 0, self::ERROR_MAX_LENGTH);
+        }
+
+        return 'FAIL: '.$errorMessage;
+    }
+}

--- a/src/Tui/Inspector/RequestLogPanel.php
+++ b/src/Tui/Inspector/RequestLogPanel.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Inspector;
+
+use Symfony\Component\Tui\Widget\AbstractWidget;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+
+final class RequestLogPanel
+{
+    private readonly TextWidget $header;
+    private readonly TextWidget $body;
+    private readonly ContainerWidget $container;
+
+    public function __construct()
+    {
+        $this->header = new TextWidget('Request Log');
+        $this->body = new TextWidget('No data');
+        $this->container = new ContainerWidget();
+        $this->container->add($this->header);
+        $this->container->add($this->body);
+    }
+
+    public function widget(): AbstractWidget
+    {
+        return $this->container;
+    }
+
+    public function update(?InspectorSnapshot $snapshot, bool $busy): void
+    {
+        $this->header->setText($busy ? 'Request Log  polling...' : 'Request Log');
+
+        if (null === $snapshot) {
+            $this->body->setText('No data');
+
+            return;
+        }
+
+        if (!$snapshot->reachable) {
+            $this->body->setText('Unreachable');
+
+            return;
+        }
+
+        $this->body->setText(RequestLogFormatter::format($snapshot->requests));
+    }
+
+    public function headerText(): string
+    {
+        return $this->header->getText();
+    }
+
+    public function bodyText(): string
+    {
+        return $this->body->getText();
+    }
+}

--- a/src/Tui/Inspector/StateFormatter.php
+++ b/src/Tui/Inspector/StateFormatter.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Inspector;
+
+final class StateFormatter
+{
+    private const KNOWN_DOMAINS = [
+        'weather',
+        'trackers',
+        'notifications',
+        'customApps',
+        'indicators',
+        'brightness',
+        'settings',
+        'icons',
+    ];
+
+    /**
+     * @param array<string, mixed>|null $state
+     */
+    public static function format(?array $state): string
+    {
+        if (null === $state || [] === $state) {
+            return 'No data';
+        }
+
+        $lines = [];
+
+        foreach (self::KNOWN_DOMAINS as $domain) {
+            $lines[] = \sprintf('[%s]', $domain);
+            if (!\array_key_exists($domain, $state)) {
+                $lines[] = '  (empty)';
+                continue;
+            }
+            self::appendBodyLines($lines, $state[$domain]);
+        }
+
+        $extraDomains = array_diff(array_keys($state), self::KNOWN_DOMAINS);
+        sort($extraDomains);
+        foreach ($extraDomains as $domain) {
+            $lines[] = \sprintf('[%s]', $domain);
+            self::appendBodyLines($lines, $state[$domain]);
+        }
+
+        while ([] !== $lines && '' === end($lines)) {
+            array_pop($lines);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param list<string> $lines
+     */
+    private static function appendBodyLines(array &$lines, mixed $value): void
+    {
+        if (!\is_array($value)) {
+            $lines[] = '  '.self::renderScalar($value);
+
+            return;
+        }
+
+        if ([] === $value) {
+            $lines[] = '  (empty)';
+
+            return;
+        }
+
+        foreach ($value as $key => $itemValue) {
+            $lines[] = \sprintf('  %s: %s', (string) $key, self::renderValue($itemValue));
+        }
+    }
+
+    private static function renderValue(mixed $value): string
+    {
+        if (\is_array($value)) {
+            return (string) json_encode($value, \JSON_UNESCAPED_SLASHES);
+        }
+
+        return self::renderScalar($value);
+    }
+
+    private static function renderScalar(mixed $value): string
+    {
+        if (\is_string($value)) {
+            return $value;
+        }
+        if (true === $value) {
+            return 'true';
+        }
+        if (false === $value) {
+            return 'false';
+        }
+        if (null === $value) {
+            return 'null';
+        }
+        if (\is_int($value) || \is_float($value)) {
+            return (string) $value;
+        }
+
+        return (string) json_encode($value, \JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/src/Tui/Inspector/StateInspectorPanel.php
+++ b/src/Tui/Inspector/StateInspectorPanel.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Inspector;
+
+use Symfony\Component\Tui\Widget\AbstractWidget;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+
+final class StateInspectorPanel
+{
+    private readonly TextWidget $header;
+    private readonly TextWidget $body;
+    private readonly ContainerWidget $container;
+
+    public function __construct()
+    {
+        $this->header = new TextWidget('State Inspector');
+        $this->body = new TextWidget('No data');
+        $this->container = new ContainerWidget();
+        $this->container->add($this->header);
+        $this->container->add($this->body);
+    }
+
+    public function widget(): AbstractWidget
+    {
+        return $this->container;
+    }
+
+    public function update(?InspectorSnapshot $snapshot, bool $busy): void
+    {
+        $this->header->setText($busy ? 'State Inspector  polling...' : 'State Inspector');
+
+        if (null === $snapshot) {
+            $this->body->setText('No data');
+
+            return;
+        }
+
+        if (!$snapshot->reachable) {
+            $this->body->setText('Unreachable');
+
+            return;
+        }
+
+        $this->body->setText(StateFormatter::format($snapshot->state));
+    }
+
+    public function headerText(): string
+    {
+        return $this->header->getText();
+    }
+
+    public function bodyText(): string
+    {
+        return $this->body->getText();
+    }
+}

--- a/tests/Command/TuiCommandWiringTest.php
+++ b/tests/Command/TuiCommandWiringTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\TuiCommand;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class TuiCommandWiringTest extends KernelTestCase
+{
+    public function testTuiCommandResolvesFromContainerWithoutDiErrors(): void
+    {
+        self::bootKernel();
+
+        $command = self::getContainer()->get(TuiCommand::class);
+
+        self::assertInstanceOf(TuiCommand::class, $command);
+    }
+}

--- a/tests/Tui/Inspector/InspectorHttpClientTest.php
+++ b/tests/Tui/Inspector/InspectorHttpClientTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Inspector;
+
+use App\Tui\Inspector\InspectorHttpClient;
+use PHPUnit\Framework\TestCase;
+
+final class InspectorHttpClientTest extends TestCase
+{
+    public function testFetchReturnsUnreachableWhenBaseUrlIsNull(): void
+    {
+        $client = new InspectorHttpClient();
+
+        $snapshot = $client->fetch(null);
+
+        self::assertFalse($snapshot->reachable);
+        self::assertSame('no base URL configured', $snapshot->errorMessage);
+        self::assertNull($snapshot->state);
+        self::assertNull($snapshot->requests);
+    }
+
+    public function testFetchReturnsUnreachableWhenBaseUrlIsEmptyString(): void
+    {
+        $client = new InspectorHttpClient();
+
+        $snapshot = $client->fetch('');
+
+        self::assertFalse($snapshot->reachable);
+        self::assertSame('no base URL configured', $snapshot->errorMessage);
+    }
+
+    public function testFetchReturnsUnreachableWhenHostIsUnroutable(): void
+    {
+        $client = new InspectorHttpClient(timeoutSeconds: 0.1);
+
+        $snapshot = $client->fetch('http://127.0.0.1:1/');
+
+        self::assertFalse($snapshot->reachable);
+        self::assertSame('connection failed', $snapshot->errorMessage);
+        self::assertNull($snapshot->state);
+        self::assertNull($snapshot->requests);
+    }
+}

--- a/tests/Tui/Inspector/InspectorPollerTest.php
+++ b/tests/Tui/Inspector/InspectorPollerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Inspector;
+
+use App\Tui\Inspector\InspectorPoller;
+use App\Tui\Inspector\InspectorSnapshot;
+use App\Tui\Inspector\InspectorTransport;
+use PHPUnit\Framework\TestCase;
+
+final class InspectorPollerTest extends TestCase
+{
+    public function testPollIfDueDoesNothingBeforeIntervalElapsed(): void
+    {
+        $stubClient = new CountingInspectorHttpClientStub();
+        $poller = new InspectorPoller($stubClient, 'http://example.invalid', pollIntervalSeconds: 1.0);
+
+        $firstResult = $poller->pollIfDue(0.4);
+        $secondResult = $poller->pollIfDue(0.4);
+
+        self::assertFalse($firstResult);
+        self::assertFalse($secondResult);
+        self::assertSame(0, $stubClient->fetchCount);
+        self::assertNull($poller->getLatestSnapshot());
+    }
+
+    public function testPollIfDueFiresWhenAccumulatedDeltaReachesInterval(): void
+    {
+        $stubClient = new CountingInspectorHttpClientStub();
+        $poller = new InspectorPoller($stubClient, 'http://example.invalid', pollIntervalSeconds: 1.0);
+
+        $beforeInterval = $poller->pollIfDue(0.6);
+        $atInterval = $poller->pollIfDue(0.5);
+
+        self::assertFalse($beforeInterval);
+        self::assertTrue($atInterval);
+        self::assertSame(1, $stubClient->fetchCount);
+        $latestSnapshot = $poller->getLatestSnapshot();
+        self::assertNotNull($latestSnapshot);
+        self::assertTrue($latestSnapshot->reachable);
+    }
+
+    public function testPollAlwaysFiresAndResetsAccumulator(): void
+    {
+        $stubClient = new CountingInspectorHttpClientStub();
+        $poller = new InspectorPoller($stubClient, 'http://example.invalid', pollIntervalSeconds: 1.0);
+
+        $poller->pollIfDue(0.5);
+        $snapshot = $poller->poll();
+
+        self::assertSame(1, $stubClient->fetchCount);
+        self::assertSame($snapshot, $poller->getLatestSnapshot());
+
+        $immediatelyAfter = $poller->pollIfDue(0.5);
+        self::assertFalse($immediatelyAfter);
+        self::assertSame(1, $stubClient->fetchCount);
+
+        $afterFullInterval = $poller->pollIfDue(0.5);
+        self::assertTrue($afterFullInterval);
+        self::assertSame(2, $stubClient->fetchCount);
+    }
+
+    public function testNegativeDeltaIsClampedToZero(): void
+    {
+        $stubClient = new CountingInspectorHttpClientStub();
+        $poller = new InspectorPoller($stubClient, 'http://example.invalid', pollIntervalSeconds: 1.0);
+
+        $poller->pollIfDue(-100.0);
+        $poller->pollIfDue(-100.0);
+
+        self::assertSame(0, $stubClient->fetchCount);
+        self::assertNull($poller->getLatestSnapshot());
+
+        $fired = $poller->pollIfDue(1.0);
+        self::assertTrue($fired);
+        self::assertSame(1, $stubClient->fetchCount);
+    }
+}
+
+final class CountingInspectorHttpClientStub implements InspectorTransport
+{
+    public int $fetchCount = 0;
+
+    public function fetch(?string $baseUrl): InspectorSnapshot
+    {
+        ++$this->fetchCount;
+
+        return InspectorSnapshot::fromInspectPayload([
+            'state' => ['weather' => ['city' => 'Paris']],
+            'requests' => [],
+        ]);
+    }
+}

--- a/tests/Tui/Inspector/RequestLogFormatterTest.php
+++ b/tests/Tui/Inspector/RequestLogFormatterTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Inspector;
+
+use App\Tui\Inspector\RequestLogFormatter;
+use PHPUnit\Framework\TestCase;
+
+final class RequestLogFormatterTest extends TestCase
+{
+    public function testFormatReturnsNoDataWhenRequestsIsNull(): void
+    {
+        self::assertSame('No data', RequestLogFormatter::format(null));
+    }
+
+    public function testFormatReturnsNoDataWhenRequestsIsEmpty(): void
+    {
+        self::assertSame('No data', RequestLogFormatter::format([]));
+    }
+
+    public function testFormatRendersNewestFirst(): void
+    {
+        $requests = [
+            [
+                'method' => 'GET',
+                'path' => '/api/oldest',
+                'timestamp' => '2026-05-25T10:00:00+00:00',
+                'validation' => ['valid' => true],
+            ],
+            [
+                'method' => 'POST',
+                'path' => '/api/middle',
+                'timestamp' => '2026-05-25T10:00:01+00:00',
+                'validation' => ['valid' => true],
+            ],
+            [
+                'method' => 'DELETE',
+                'path' => '/api/newest',
+                'timestamp' => '2026-05-25T10:00:02+00:00',
+                'validation' => ['valid' => true],
+            ],
+        ];
+
+        $output = RequestLogFormatter::format($requests);
+        $lines = explode("\n", $output);
+
+        self::assertCount(3, $lines);
+        self::assertStringContainsString('/api/newest', $lines[0]);
+        self::assertStringContainsString('/api/middle', $lines[1]);
+        self::assertStringContainsString('/api/oldest', $lines[2]);
+    }
+
+    public function testFormatRendersOkValidation(): void
+    {
+        $requests = [
+            [
+                'method' => 'GET',
+                'path' => '/api/health',
+                'timestamp' => '2026-05-25T09:15:30+00:00',
+                'validation' => ['valid' => true],
+            ],
+        ];
+
+        $output = RequestLogFormatter::format($requests);
+
+        self::assertSame('09:15:30  GET  /api/health  OK', $output);
+    }
+
+    public function testFormatRendersFailValidationWithTruncatedError(): void
+    {
+        $longErrorMessage = str_repeat('x', 120);
+        $requests = [
+            [
+                'method' => 'POST',
+                'path' => '/api/broken',
+                'timestamp' => '2026-05-25T09:15:30+00:00',
+                'validation' => ['valid' => false, 'error' => $longErrorMessage],
+            ],
+        ];
+
+        $output = RequestLogFormatter::format($requests);
+
+        self::assertSame(
+            '09:15:30  POST  /api/broken  FAIL: '.str_repeat('x', 60),
+            $output,
+        );
+    }
+
+    public function testFormatHandlesMalformedTimestampGracefully(): void
+    {
+        $requests = [
+            [
+                'method' => 'GET',
+                'path' => '/api/x',
+                'timestamp' => 'not-a-date',
+                'validation' => ['valid' => true],
+            ],
+        ];
+
+        $output = RequestLogFormatter::format($requests);
+
+        self::assertSame('??:??:??  GET  /api/x  OK', $output);
+    }
+}

--- a/tests/Tui/Inspector/RequestLogPanelTest.php
+++ b/tests/Tui/Inspector/RequestLogPanelTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Inspector;
+
+use App\Tui\Inspector\InspectorSnapshot;
+use App\Tui\Inspector\RequestLogPanel;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+
+final class RequestLogPanelTest extends TestCase
+{
+    public function testWidgetReturnsContainerWithHeaderAndBody(): void
+    {
+        $panel = new RequestLogPanel();
+
+        self::assertInstanceOf(ContainerWidget::class, $panel->widget());
+        self::assertSame('Request Log', $panel->headerText());
+        self::assertSame('No data', $panel->bodyText());
+    }
+
+    public function testUpdateWithNullSnapshotShowsNoData(): void
+    {
+        $panel = new RequestLogPanel();
+
+        $panel->update(null, busy: false);
+
+        self::assertSame('No data', $panel->bodyText());
+        self::assertSame('Request Log', $panel->headerText());
+    }
+
+    public function testUpdateWithUnreachableSnapshotShowsUnreachable(): void
+    {
+        $panel = new RequestLogPanel();
+
+        $panel->update(InspectorSnapshot::unreachable('connection failed'), busy: false);
+
+        self::assertSame('Unreachable', $panel->bodyText());
+    }
+
+    public function testUpdateWithReachableSnapshotDelegatesToFormatter(): void
+    {
+        $panel = new RequestLogPanel();
+        $snapshot = InspectorSnapshot::fromInspectPayload([
+            'state' => [],
+            'requests' => [
+                [
+                    'timestamp' => '2026-05-25T10:00:00+00:00',
+                    'method' => 'POST',
+                    'path' => '/api/v2/notifications',
+                    'validation' => ['valid' => true],
+                ],
+            ],
+        ]);
+
+        $panel->update($snapshot, busy: false);
+
+        self::assertStringContainsString('POST', $panel->bodyText());
+        self::assertStringContainsString('/api/v2/notifications', $panel->bodyText());
+        self::assertStringContainsString('OK', $panel->bodyText());
+    }
+
+    public function testUpdateWithBusyTrueAppendsPollingHintToHeader(): void
+    {
+        $panel = new RequestLogPanel();
+
+        $panel->update(null, busy: true);
+
+        self::assertSame('Request Log  polling...', $panel->headerText());
+    }
+}

--- a/tests/Tui/Inspector/StateFormatterTest.php
+++ b/tests/Tui/Inspector/StateFormatterTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Inspector;
+
+use App\Tui\Inspector\StateFormatter;
+use PHPUnit\Framework\TestCase;
+
+final class StateFormatterTest extends TestCase
+{
+    public function testFormatReturnsNoDataWhenStateIsNull(): void
+    {
+        self::assertSame('No data', StateFormatter::format(null));
+    }
+
+    public function testFormatReturnsNoDataWhenStateIsEmpty(): void
+    {
+        self::assertSame('No data', StateFormatter::format([]));
+    }
+
+    public function testFormatRendersAllKnownDomainsInDeterministicOrder(): void
+    {
+        $state = [
+            'icons' => ['count' => 3],
+            'settings' => ['theme' => 'dark'],
+            'brightness' => ['level' => 80],
+            'indicators' => ['battery' => true],
+            'customApps' => ['installed' => ['weather', 'clock']],
+            'notifications' => ['unread' => 0],
+            'trackers' => ['active' => 2],
+            'weather' => ['city' => 'Paris'],
+        ];
+
+        $output = StateFormatter::format($state);
+
+        $expected = <<<EOT
+            [weather]
+              city: Paris
+            [trackers]
+              active: 2
+            [notifications]
+              unread: 0
+            [customApps]
+              installed: ["weather","clock"]
+            [indicators]
+              battery: true
+            [brightness]
+              level: 80
+            [settings]
+              theme: dark
+            [icons]
+              count: 3
+            EOT;
+
+        self::assertSame($expected, $output);
+    }
+
+    public function testFormatRendersUnknownDomainAfterKnownOnes(): void
+    {
+        $state = [
+            'weather' => ['city' => 'Paris'],
+            'zebra' => ['stripes' => 12],
+            'alpha' => ['value' => 'a'],
+        ];
+
+        $output = StateFormatter::format($state);
+        $outputLines = explode("\n", $output);
+
+        $alphaPosition = array_search('[alpha]', $outputLines, true);
+        $zebraPosition = array_search('[zebra]', $outputLines, true);
+        $weatherPosition = array_search('[weather]', $outputLines, true);
+
+        self::assertIsInt($alphaPosition);
+        self::assertIsInt($zebraPosition);
+        self::assertIsInt($weatherPosition);
+        self::assertLessThan($alphaPosition, $weatherPosition);
+        self::assertLessThan($zebraPosition, $alphaPosition);
+    }
+
+    public function testFormatShowsEmptyPlaceholderWhenDomainIsMissing(): void
+    {
+        $state = [
+            'weather' => ['city' => 'Paris'],
+        ];
+
+        $output = StateFormatter::format($state);
+        $outputLines = explode("\n", $output);
+
+        $trackersHeaderPosition = array_search('[trackers]', $outputLines, true);
+        self::assertIsInt($trackersHeaderPosition);
+        self::assertSame('  (empty)', $outputLines[$trackersHeaderPosition + 1]);
+    }
+}

--- a/tests/Tui/Inspector/StateInspectorPanelTest.php
+++ b/tests/Tui/Inspector/StateInspectorPanelTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Inspector;
+
+use App\Tui\Inspector\InspectorSnapshot;
+use App\Tui\Inspector\StateInspectorPanel;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+
+final class StateInspectorPanelTest extends TestCase
+{
+    public function testWidgetReturnsContainerWithHeaderAndBody(): void
+    {
+        $panel = new StateInspectorPanel();
+
+        self::assertInstanceOf(ContainerWidget::class, $panel->widget());
+        self::assertSame('State Inspector', $panel->headerText());
+        self::assertSame('No data', $panel->bodyText());
+    }
+
+    public function testUpdateWithNullSnapshotShowsNoData(): void
+    {
+        $panel = new StateInspectorPanel();
+
+        $panel->update(null, busy: false);
+
+        self::assertSame('No data', $panel->bodyText());
+        self::assertSame('State Inspector', $panel->headerText());
+    }
+
+    public function testUpdateWithUnreachableSnapshotShowsUnreachable(): void
+    {
+        $panel = new StateInspectorPanel();
+
+        $panel->update(InspectorSnapshot::unreachable('connection failed'), busy: false);
+
+        self::assertSame('Unreachable', $panel->bodyText());
+    }
+
+    public function testUpdateWithReachableSnapshotDelegatesToFormatter(): void
+    {
+        $panel = new StateInspectorPanel();
+        $snapshot = InspectorSnapshot::fromInspectPayload([
+            'state' => ['weather' => ['city' => 'Paris']],
+            'requests' => [],
+        ]);
+
+        $panel->update($snapshot, busy: false);
+
+        self::assertStringStartsWith('[weather]', $panel->bodyText());
+    }
+
+    public function testUpdateWithBusyTrueAppendsPollingHintToHeader(): void
+    {
+        $panel = new StateInspectorPanel();
+
+        $panel->update(null, busy: true);
+
+        self::assertSame('State Inspector  polling...', $panel->headerText());
+    }
+}


### PR DESCRIPTION
## Summary

Implements two read-only dev-mode TUI panels (#29) that poll the simulator's `GET /__inspect` endpoint every 1s and render the state by domain plus the last 50 requests. Connection failures degrade gracefully to `Unreachable` while the TUI stays interactive. Data is sourced only over HTTP — no in-process `ResettableState` injection (AC-ARCH-4).

Polling is wired via `Tui::onTick` with accumulated `TickEvent::getDeltaTime()`; an initial synchronous poll runs before `Tui::run()` so the panels populate within 2s of launch. Panels are visible only in `TuiMode::Dev`.

Closes #29

## Review notes (auto-fix disabled)

A fresh-eye review surfaced **0 critical, 5 important, 6 minor** findings — full report in `.claude-work/29/review.md`. Highlights worth addressing as a small follow-up:

1. `polling...` indicator is currently dead code: the tick listener always passes `busy: false` (the poll is synchronous and completes before update). Either wire the busy hint properly or remove the parameter.
2. `?string $baseUrl` is held by both `InspectorPoller` and `InspectorHttpClient`/`InspectorTransport::fetch()`. Consolidate ownership in the client and make `fetch(): InspectorSnapshot` parameterless.
3. `headerText()` / `bodyText()` on the two panels are test-only seams exposed publicly — mark `@internal` or test via the public widget.
4. Document the oldest-first ordering of `requests` in `InspectorSnapshot` (or sort by timestamp in the formatter for robustness).
5. Dead `while` loop in `StateFormatter::format()` (lines 47-49) — no branch pushes an empty string into `$lines`.

Minor: UTF-8-unsafe `substr` for truncation, in-file test stub class, `isset && true ===` style, and a scope-narrow `TuiCommandWiringTest` name.

## Test plan

- [x] `vendor/bin/phpunit` — 77 tests / 188 assertions OK
- [x] `vendor/bin/phpstan analyse --memory-limit=512M` — no errors
- [x] `vendor/bin/php-cs-fixer fix` — no changes
- [x] Smoke check: `echo q | timeout 2 bin/console app:tui` — exit 0, no PHP fatal
- [ ] Manual: launch `docker compose exec php bin/console app:tui` and confirm both panels populate within ~2s when the simulator is up; press Q to exit