### PR TITLE
feat(tui): add shared scenarios menu with OpenAPI validation (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # pixelcast-client
+
+### TUI Scenarios
+
+The `[1] Scenarios` menu in `bin/console app:tui` sends predefined REST calls
+to the configured ESP32 target. It is available in both dev and prod modes;
+the only difference is the target URL, taken from `PIXELCAST_DEVICE_BASE_URL`
+(the local simulator in dev, the real device in prod). The `Reset simulator`
+entry is dev-only and is hidden when the TUI runs against a real device.
+
+Each scenario payload is validated against `sync/openapi.yaml` before the
+request leaves the process; validation failures show inline as
+`VALIDATION ...` and the HTTP call is skipped. Successful dispatches show
+`OK <status>`, transport errors show `FAIL HTTP <status>: <snippet>` (or
+`FAIL <reason>` for non-HTTP errors), and unreachable targets show
+`UNREACHABLE <reason>`.
+
+Scenarios live in `src/Tui/Scenarios/ScenarioCatalog.php` — add new entries
+there to extend the menu.

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -39,5 +39,19 @@ services:
         arguments:
             $specPath: '%kernel.project_dir%/sync/openapi.yaml'
 
+    App\Tui\Scenarios\Validation\OutboundOpenApiValidatorFactory: ~
+
+    league_openapi_psr7_validator.outbound_request_validator:
+        class: League\OpenAPIValidation\PSR7\RequestValidator
+        factory: ['@App\Tui\Scenarios\Validation\OutboundOpenApiValidatorFactory', 'create']
+
+    App\Tui\Scenarios\Validation\OutboundPayloadValidator:
+        arguments:
+            $validator: '@league_openapi_psr7_validator.outbound_request_validator'
+
+    App\Tui\Scenarios\Transport\ScenarioHttpClient: ~
+
+    App\Tui\Scenarios\Transport\ScenarioTransport: '@App\Tui\Scenarios\Transport\ScenarioHttpClient'
+
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -11,13 +11,19 @@ use App\Tui\Inspector\StateInspectorPanel;
 use App\Tui\Menu\TuiMenuFactory;
 use App\Tui\Reachability\DeviceReachabilityProbe;
 use App\Tui\Reachability\DeviceReachabilityResult;
+use App\Tui\Scenarios\Panel\ScenariosPanel;
+use App\Tui\Scenarios\ScenarioCatalog;
+use App\Tui\Scenarios\ScenarioDispatcher;
+use App\Tui\TerminalSafeText;
 use App\Tui\TuiMode;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Tui\Event\CancelEvent;
 use Symfony\Component\Tui\Event\InputEvent;
+use Symfony\Component\Tui\Event\SelectEvent;
 use Symfony\Component\Tui\Event\TickEvent;
 use Symfony\Component\Tui\Tui;
 use Symfony\Component\Tui\Widget\AbstractWidget;
@@ -28,6 +34,8 @@ use Symfony\Component\Tui\Widget\TextWidget;
 #[AsCommand(name: 'app:tui', description: 'Opens the PixelCast unified terminal interface')]
 final class TuiCommand extends Command
 {
+    private TuiView $currentView = TuiView::Main;
+
     public function __construct(
         #[Autowire('%kernel.environment%')]
         private readonly string $appEnvironment,
@@ -35,6 +43,8 @@ final class TuiCommand extends Command
         private readonly ?string $deviceBaseUrl,
         private readonly DeviceReachabilityProbe $deviceReachabilityProbe,
         private readonly InspectorTransport $inspectorHttpClient,
+        private readonly ScenarioCatalog $scenarioCatalog,
+        private readonly ScenarioDispatcher $scenarioDispatcher,
     ) {
         parent::__construct();
     }
@@ -45,7 +55,9 @@ final class TuiCommand extends Command
         $reachabilityResult = $this->deviceReachabilityProbe->probe($this->deviceBaseUrl);
 
         $tui = new Tui();
-        $tui->add($this->buildMainMenuWidget($mode));
+
+        $menuSelectList = $this->buildMainMenuSelectList($mode);
+        $mainBodyContainer = $this->buildMainBodyContainer($menuSelectList);
 
         $inspectorPoller = null;
         $stateInspectorPanel = null;
@@ -63,10 +75,17 @@ final class TuiCommand extends Command
             $stateInspectorPanel->update($initialSnapshot, busy: false);
             $requestLogPanel->update($initialSnapshot, busy: false);
 
-            $tui->add($stateInspectorPanel->widget());
-            $tui->add($requestLogPanel->widget());
+            $mainBodyContainer->add($stateInspectorPanel->widget());
+            $mainBodyContainer->add($requestLogPanel->widget());
         }
 
+        $scenariosPanel = new ScenariosPanel($this->scenarioCatalog, $mode);
+
+        $viewContainer = new ContainerWidget();
+        $viewContainer->expandVertically(true);
+        $viewContainer->add($mainBodyContainer);
+
+        $tui->add($viewContainer);
         $tui->add($this->buildStatusBarWidget($mode, $reachabilityResult));
 
         if (null !== $inspectorPoller) {
@@ -77,6 +96,41 @@ final class TuiCommand extends Command
                 $requestLogPanel,
             ));
         }
+
+        $tui->addListener(function (SelectEvent $event) use ($tui, $menuSelectList, $viewContainer, $mainBodyContainer, $scenariosPanel): void {
+            if ($event->getTarget() !== $menuSelectList) {
+                return;
+            }
+            if ('scenarios' !== $event->getValue()) {
+                return;
+            }
+
+            $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, TuiView::Scenarios);
+        });
+
+        $tui->addListener(function (SelectEvent $event) use ($tui, $scenariosPanel, $mode): void {
+            if ($event->getTarget() !== $scenariosPanel->selectListWidget()) {
+                return;
+            }
+
+            $scenario = $this->scenarioCatalog->findById($event->getValue(), $mode);
+            if (null === $scenario) {
+                return;
+            }
+
+            $result = $this->scenarioDispatcher->dispatch($scenario);
+            $scenariosPanel->showResult($result);
+            $tui->requestRender();
+        });
+
+        $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $mainBodyContainer, $scenariosPanel): void {
+            if ($event->getTarget() !== $scenariosPanel->selectListWidget()) {
+                return;
+            }
+
+            $scenariosPanel->clearResult();
+            $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, TuiView::Main);
+        });
 
         // Registered on the Tui (not on a widget) so Q quits before focus
         // routing, regardless of which sub-panel currently has focus.
@@ -91,6 +145,27 @@ final class TuiCommand extends Command
         $tui->run();
 
         return Command::SUCCESS;
+    }
+
+    private function switchView(
+        Tui $tui,
+        ContainerWidget $viewContainer,
+        ContainerWidget $mainBodyContainer,
+        ScenariosPanel $scenariosPanel,
+        TuiView $next,
+    ): void {
+        if ($this->currentView === $next) {
+            return;
+        }
+
+        $this->currentView = $next;
+        $viewContainer->clear();
+        $viewContainer->add(match ($next) {
+            TuiView::Main => $mainBodyContainer,
+            TuiView::Scenarios => $scenariosPanel->widget(),
+        });
+
+        $tui->requestRender();
     }
 
     private function buildInspectorTickListener(
@@ -117,16 +192,19 @@ final class TuiCommand extends Command
         };
     }
 
-    private function buildMainMenuWidget(TuiMode $mode): AbstractWidget
+    private function buildMainMenuSelectList(TuiMode $mode): SelectListWidget
     {
         $menuItems = TuiMenuFactory::buildForMode($mode);
         $selectListItems = TuiMenuFactory::toSelectListItems($menuItems);
 
-        $selectList = new SelectListWidget($selectListItems, maxVisible: \count($selectListItems));
+        return new SelectListWidget($selectListItems, maxVisible: \count($selectListItems));
+    }
 
+    private function buildMainBodyContainer(SelectListWidget $menuSelectList): ContainerWidget
+    {
         $mainPanel = new ContainerWidget();
         $mainPanel->expandVertically(true);
-        $mainPanel->add($selectList);
+        $mainPanel->add($menuSelectList);
 
         return $mainPanel;
     }
@@ -151,9 +229,8 @@ final class TuiCommand extends Command
             return 'n/a';
         }
 
-        // The URL comes from an env var and TextWidget renders content
-        // verbatim including ANSI escapes, so we strip C0/C1 controls and
-        // DEL to prevent terminal-escape injection.
-        return preg_replace("/[\x00-\x08\x0b-\x1f\x7f]|\xc2[\x80-\x9f]/", '', $baseUrl) ?? '';
+        // URL comes from an env var rendered verbatim by TextWidget; strip
+        // C0/C1 controls to block terminal-escape injection.
+        return TerminalSafeText::stripControlBytes($baseUrl);
     }
 }

--- a/src/Command/TuiView.php
+++ b/src/Command/TuiView.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+enum TuiView: string
+{
+    case Main = 'main';
+    case Scenarios = 'scenarios';
+}

--- a/src/Tui/Scenarios/DeviceBaseUrl.php
+++ b/src/Tui/Scenarios/DeviceBaseUrl.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Scenarios;
+
+final class DeviceBaseUrl
+{
+    public const string DEFAULT = 'http://simulator:8080';
+
+    public static function resolve(?string $configured): string
+    {
+        if (null === $configured || '' === $configured) {
+            return self::DEFAULT;
+        }
+
+        return $configured;
+    }
+}

--- a/src/Tui/Scenarios/Panel/ScenariosPanel.php
+++ b/src/Tui/Scenarios/Panel/ScenariosPanel.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Scenarios\Panel;
+
+use App\Tui\Scenarios\ScenarioCatalog;
+use App\Tui\Scenarios\ScenarioResult;
+use App\Tui\Scenarios\ScenarioResultKind;
+use App\Tui\TerminalSafeText;
+use App\Tui\TuiMode;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\SelectListWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+
+final class ScenariosPanel
+{
+    private const string HEADER_TEXT = 'Scenarios - [Enter] dispatch  [Esc] back';
+    private const string SEPARATOR_TEXT = '----------------------------------------------------------------';
+
+    private readonly TextWidget $resultLine;
+    private readonly SelectListWidget $list;
+    private readonly ContainerWidget $container;
+
+    public function __construct(ScenarioCatalog $catalog, TuiMode $mode)
+    {
+        $items = self::buildSelectListItems($catalog, $mode);
+
+        $header = new TextWidget(self::HEADER_TEXT);
+        $separator = new TextWidget(self::SEPARATOR_TEXT);
+        $this->list = new SelectListWidget(items: $items, maxVisible: \count($items));
+        $this->resultLine = new TextWidget('');
+
+        $this->container = new ContainerWidget();
+        $this->container->expandVertically(true);
+        $this->container->add($header);
+        $this->container->add($separator);
+        $this->container->add($this->list);
+        $this->container->add($this->resultLine);
+    }
+
+    public function widget(): ContainerWidget
+    {
+        return $this->container;
+    }
+
+    public function selectListWidget(): SelectListWidget
+    {
+        return $this->list;
+    }
+
+    public function showResult(ScenarioResult $result): void
+    {
+        $this->resultLine->setText(TerminalSafeText::stripControlBytes($this->formatResult($result)));
+    }
+
+    public function clearResult(): void
+    {
+        $this->resultLine->setText('');
+    }
+
+    public function currentResultText(): string
+    {
+        return $this->resultLine->getText();
+    }
+
+    private function formatResult(ScenarioResult $result): string
+    {
+        return match ($result->kind) {
+            ScenarioResultKind::Success => $this->formatSuccess($result),
+            ScenarioResultKind::ValidationFailure => 'VALIDATION '.$result->message,
+            ScenarioResultKind::TransportFailure => null !== $result->httpStatus
+                ? \sprintf('FAIL HTTP %d: %s', $result->httpStatus, $result->message)
+                : 'FAIL '.$result->message,
+            ScenarioResultKind::Unreachable => 'UNREACHABLE '.$result->message,
+        };
+    }
+
+    private function formatSuccess(ScenarioResult $result): string
+    {
+        $statusOnly = 'OK '.($result->httpStatus ?? 0);
+
+        if ('' === $result->message || 'OK' === $result->message) {
+            return $statusOnly;
+        }
+
+        return $statusOnly.': '.$result->message;
+    }
+
+    /**
+     * @return list<array{value: string, label: string, description: string}>
+     */
+    private static function buildSelectListItems(ScenarioCatalog $catalog, TuiMode $mode): array
+    {
+        $items = [];
+        foreach ($catalog->all($mode) as $scenario) {
+            $items[] = [
+                'value' => $scenario->id,
+                'label' => $scenario->label,
+                'description' => $scenario->description,
+            ];
+        }
+
+        return $items;
+    }
+}

--- a/src/Tui/Scenarios/ScenarioCatalog.php
+++ b/src/Tui/Scenarios/ScenarioCatalog.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Scenarios;
+
+use App\Tui\TuiMode;
+
+final class ScenarioCatalog
+{
+    private const string DEV_ONLY_RESET_ID = 'reset-simulator';
+
+    /**
+     * @return list<ScenarioDefinition>
+     */
+    public function all(TuiMode $mode): array
+    {
+        $scenarios = self::buildScenarios();
+
+        if (TuiMode::Prod === $mode) {
+            return array_values(array_filter(
+                $scenarios,
+                static fn (ScenarioDefinition $scenario): bool => self::DEV_ONLY_RESET_ID !== $scenario->id,
+            ));
+        }
+
+        return $scenarios;
+    }
+
+    public function findById(string $id, TuiMode $mode): ?ScenarioDefinition
+    {
+        foreach ($this->all($mode) as $scenario) {
+            if ($scenario->id === $id) {
+                return $scenario;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<ScenarioDefinition>
+     */
+    private static function buildScenarios(): array
+    {
+        return [
+            new ScenarioDefinition(
+                id: 'weather',
+                label: 'Weather',
+                description: 'current conditions + 3-day forecast',
+                httpMethod: 'POST',
+                path: '/weather',
+                body: [
+                    'current' => [
+                        'icon' => 'w_clear_day',
+                        'temp' => 22,
+                        'temp_min' => 16,
+                        'temp_max' => 29,
+                        'humidity' => 50,
+                    ],
+                    'forecast' => [
+                        [
+                            'day' => 'MON',
+                            'icon' => 'w_partly_day',
+                            'temp_min' => 14,
+                            'temp_max' => 23,
+                        ],
+                    ],
+                ],
+            ),
+            new ScenarioDefinition(
+                id: 'tracker-btc',
+                label: 'Tracker - BTC (crypto)',
+                description: 'crypto tracker, USD price + sparkline',
+                httpMethod: 'POST',
+                path: '/tracker',
+                queryParams: ['name' => 'BTC'],
+                body: [
+                    'symbol' => 'BTC',
+                    'icon' => 'bitcoin',
+                    'currency' => 'USD',
+                    'value' => 98452.30,
+                    'change' => 2.14,
+                    'sparkline' => [92100, 89300, 93200, 91800, 95400, 94100, 97600, 96200, 98452],
+                    'symbolColor' => '#FF8800',
+                    'sparklineColor' => '#00D4FF',
+                ],
+            ),
+            new ScenarioDefinition(
+                id: 'tracker-aapl',
+                label: 'Tracker - AAPL (stock)',
+                description: 'stock tracker, USD price',
+                httpMethod: 'POST',
+                path: '/tracker',
+                queryParams: ['name' => 'AAPL'],
+                body: [
+                    'symbol' => 'AAPL',
+                    'icon' => 'stock',
+                    'currency' => 'USD',
+                    'value' => 213.40,
+                    'change' => -0.4,
+                ],
+            ),
+            new ScenarioDefinition(
+                id: 'tracker-spy',
+                label: 'Tracker - SPY (ETF/index)',
+                description: 'ETF tracker, USD price',
+                httpMethod: 'POST',
+                path: '/tracker',
+                queryParams: ['name' => 'SPY'],
+                body: [
+                    'symbol' => 'SPY',
+                    'currency' => 'USD',
+                    'value' => 528.10,
+                    'change' => 0.1,
+                ],
+            ),
+            new ScenarioDefinition(
+                id: 'notification-standard',
+                label: 'Notification - standard',
+                description: 'inline message, 5 s default duration',
+                httpMethod: 'POST',
+                path: '/notify',
+                body: [
+                    'text' => 'New message!',
+                    'icon' => 'mail',
+                    'color' => '#0096FF',
+                    'duration' => 5000,
+                ],
+            ),
+            new ScenarioDefinition(
+                id: 'notification-urgent',
+                label: 'Notification - urgent',
+                description: 'urgent alert, persists until acked',
+                httpMethod: 'POST',
+                path: '/notify',
+                body: [
+                    'text' => 'Alert!',
+                    'icon' => 'warning',
+                    'color' => '#FF0000',
+                    'urgent' => true,
+                    'hold' => true,
+                ],
+            ),
+            new ScenarioDefinition(
+                id: 'custom-app-demo',
+                label: 'Custom App - demo app',
+                description: 'single named demo custom app',
+                httpMethod: 'POST',
+                path: '/custom',
+                queryParams: ['name' => 'demo'],
+                body: [
+                    'text' => 'Hello World',
+                    'icon' => 'smiley',
+                    'color' => '#FF8800',
+                    'duration' => 10000,
+                ],
+            ),
+            new ScenarioDefinition(
+                id: 'indicator-slot-1',
+                label: 'Indicator - slot 1 (green)',
+                description: 'solid green on slot 1',
+                httpMethod: 'POST',
+                path: '/indicator1',
+                body: [
+                    'mode' => 'solid',
+                    'color' => '#00FF00',
+                ],
+            ),
+            new ScenarioDefinition(
+                id: 'indicator-slot-2',
+                label: 'Indicator - slot 2 (yellow)',
+                description: 'solid yellow on slot 2',
+                httpMethod: 'POST',
+                path: '/indicator2',
+                body: [
+                    'mode' => 'solid',
+                    'color' => '#FFFF00',
+                ],
+            ),
+            new ScenarioDefinition(
+                id: 'indicator-slot-3',
+                label: 'Indicator - slot 3 (red)',
+                description: 'blinking red on slot 3',
+                httpMethod: 'POST',
+                path: '/indicator3',
+                body: [
+                    'mode' => 'blink',
+                    'color' => '#FF0000',
+                    'blinkInterval' => 500,
+                ],
+            ),
+            new ScenarioDefinition(
+                id: 'brightness',
+                label: 'Brightness - set to 200',
+                description: 'set device brightness to 200/255',
+                httpMethod: 'POST',
+                path: '/brightness',
+                body: ['brightness' => 200],
+            ),
+            new ScenarioDefinition(
+                id: 'settings-patch',
+                label: 'Settings - patch defaultDuration=5000',
+                description: 'patch one settings key',
+                httpMethod: 'POST',
+                path: '/settings',
+                body: ['defaultDuration' => 5000],
+            ),
+            new ScenarioDefinition(
+                id: 'icon-register',
+                label: 'Icon - register sun_icon (LaMetric 2867)',
+                description: 'register a LaMetric icon by id',
+                httpMethod: 'POST',
+                path: '/icons/lametric',
+                body: ['id' => 2867, 'name' => 'sun_icon'],
+            ),
+            new ScenarioDefinition(
+                id: 'reset-simulator',
+                label: 'Reset simulator state',
+                description: 'dev-only: POST /__reset (path is outside the OpenAPI spec)',
+                httpMethod: 'POST',
+                path: '/__reset',
+                body: null,
+            ),
+        ];
+    }
+}

--- a/src/Tui/Scenarios/ScenarioDefinition.php
+++ b/src/Tui/Scenarios/ScenarioDefinition.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Scenarios;
+
+final readonly class ScenarioDefinition
+{
+    private const array ALLOWED_HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
+
+    /**
+     * @param array<string,string> $queryParams
+     * @param array<string,mixed>|null $body
+     */
+    public function __construct(
+        public string $id,
+        public string $label,
+        public string $description,
+        public string $httpMethod,
+        public string $path,
+        public array $queryParams = [],
+        public ?array $body = null,
+    ) {
+        if ('' === $this->id) {
+            throw new \InvalidArgumentException('Scenario id must not be empty.');
+        }
+        if ('' === $this->label) {
+            throw new \InvalidArgumentException('Scenario label must not be empty.');
+        }
+        if ('' === $this->path) {
+            throw new \InvalidArgumentException('Scenario path must not be empty.');
+        }
+        if (!\in_array($this->httpMethod, self::ALLOWED_HTTP_METHODS, true)) {
+            throw new \InvalidArgumentException(\sprintf('Scenario httpMethod "%s" is not supported. Allowed: %s.', $this->httpMethod, implode(', ', self::ALLOWED_HTTP_METHODS)));
+        }
+    }
+}

--- a/src/Tui/Scenarios/ScenarioDispatcher.php
+++ b/src/Tui/Scenarios/ScenarioDispatcher.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Scenarios;
+
+use App\Tui\Scenarios\Transport\ScenarioTransport;
+use App\Tui\Scenarios\Validation\OutboundPayloadValidator;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class ScenarioDispatcher
+{
+    /**
+     * Endpoints exposed by the simulator but intentionally absent from
+     * sync/openapi.yaml. Calls to these paths bypass schema validation
+     * because no schema exists to validate against.
+     */
+    private const array PATHS_OUTSIDE_OPENAPI_SPEC = ['/__reset'];
+
+    public function __construct(
+        private OutboundPayloadValidator $validator,
+        private ScenarioTransport $transport,
+        #[Autowire('%env(default::PIXELCAST_DEVICE_BASE_URL)%')]
+        private ?string $deviceBaseUrl = null,
+    ) {
+    }
+
+    public function dispatch(ScenarioDefinition $scenario): ScenarioResult
+    {
+        if (!\in_array($scenario->path, self::PATHS_OUTSIDE_OPENAPI_SPEC, true)) {
+            try {
+                $validation = $this->validator->validate($scenario);
+            } catch (\Throwable $validatorError) {
+                return ScenarioResult::transportFailure('Validator error: '.$validatorError->getMessage());
+            }
+
+            if (!$validation->valid) {
+                return ScenarioResult::validationFailure($validation->errorMessage ?? 'invalid payload');
+            }
+        }
+
+        $url = $this->buildRequestUrl($scenario);
+
+        try {
+            return $this->transport->send($scenario->httpMethod, $url, $scenario->body);
+        } catch (\Throwable $transportError) {
+            return ScenarioResult::transportFailure('Transport error: '.$transportError->getMessage());
+        }
+    }
+
+    private function buildRequestUrl(ScenarioDefinition $scenario): string
+    {
+        $baseUrl = DeviceBaseUrl::resolve($this->deviceBaseUrl);
+        $url = rtrim($baseUrl, '/').$scenario->path;
+
+        if ([] !== $scenario->queryParams) {
+            $url .= '?'.http_build_query($scenario->queryParams);
+        }
+
+        return $url;
+    }
+}

--- a/src/Tui/Scenarios/ScenarioResult.php
+++ b/src/Tui/Scenarios/ScenarioResult.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Scenarios;
+
+final readonly class ScenarioResult
+{
+    private function __construct(
+        public bool $success,
+        public ?int $httpStatus,
+        public string $message,
+        public ScenarioResultKind $kind,
+    ) {
+    }
+
+    public static function success(int $httpStatus, string $message = 'OK'): self
+    {
+        return new self(success: true, httpStatus: $httpStatus, message: $message, kind: ScenarioResultKind::Success);
+    }
+
+    public static function validationFailure(string $message): self
+    {
+        return new self(success: false, httpStatus: null, message: $message, kind: ScenarioResultKind::ValidationFailure);
+    }
+
+    public static function transportFailure(string $message, ?int $httpStatus = null): self
+    {
+        return new self(success: false, httpStatus: $httpStatus, message: $message, kind: ScenarioResultKind::TransportFailure);
+    }
+
+    public static function unreachable(string $message): self
+    {
+        return new self(success: false, httpStatus: null, message: $message, kind: ScenarioResultKind::Unreachable);
+    }
+}

--- a/src/Tui/Scenarios/ScenarioResultKind.php
+++ b/src/Tui/Scenarios/ScenarioResultKind.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Scenarios;
+
+enum ScenarioResultKind: string
+{
+    case Success = 'success';
+    case ValidationFailure = 'validation_failure';
+    case TransportFailure = 'transport_failure';
+    case Unreachable = 'unreachable';
+}

--- a/src/Tui/Scenarios/Transport/ScenarioHttpClient.php
+++ b/src/Tui/Scenarios/Transport/ScenarioHttpClient.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Scenarios\Transport;
+
+use App\Tui\Scenarios\ScenarioResult;
+
+final readonly class ScenarioHttpClient implements ScenarioTransport
+{
+    private const int TIMEOUT_SECONDS = 2;
+    private const int RESPONSE_SNIPPET_MAX_LENGTH = 200;
+
+    public function send(string $method, string $url, ?array $body): ScenarioResult
+    {
+        try {
+            $encodedBody = null !== $body
+                ? json_encode($body, \JSON_THROW_ON_ERROR)
+                : null;
+        } catch (\JsonException $jsonException) {
+            return ScenarioResult::transportFailure('Payload encoding failed: '.$jsonException->getMessage());
+        }
+
+        $streamContext = stream_context_create([
+            'http' => $this->buildHttpContextOptions($method, $encodedBody),
+        ]);
+
+        // file_get_contents emits a PHP warning on connection failure; we
+        // swallow it here because we already detect the failure via false.
+        set_error_handler(static fn (): bool => true);
+        try {
+            $responseBody = file_get_contents($url, false, $streamContext);
+            $responseHeaders = http_get_last_response_headers() ?? [];
+        } finally {
+            restore_error_handler();
+        }
+
+        if (false === $responseBody && [] === $responseHeaders) {
+            $lastError = error_get_last();
+            $reason = $lastError['message'] ?? 'unreachable';
+
+            return ScenarioResult::unreachable($reason);
+        }
+
+        $httpStatus = $this->parseHttpStatus($responseHeaders);
+        if (null === $httpStatus) {
+            return ScenarioResult::transportFailure('Unable to parse HTTP status from response');
+        }
+
+        if ($httpStatus >= 200 && $httpStatus < 300) {
+            return ScenarioResult::success($httpStatus);
+        }
+
+        $snippet = $this->trimSnippet(\is_string($responseBody) ? $responseBody : '', self::RESPONSE_SNIPPET_MAX_LENGTH);
+
+        return ScenarioResult::transportFailure($snippet, $httpStatus);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildHttpContextOptions(string $method, ?string $encodedBody): array
+    {
+        $headers = "Accept: application/json\r\n";
+        if (null !== $encodedBody) {
+            $headers .= "Content-Type: application/json\r\n";
+        }
+
+        $options = [
+            'method' => $method,
+            'timeout' => self::TIMEOUT_SECONDS,
+            'ignore_errors' => true,
+            'header' => $headers,
+        ];
+
+        if (null !== $encodedBody) {
+            $options['content'] = $encodedBody;
+        }
+
+        return $options;
+    }
+
+    /**
+     * @param list<string> $headers
+     */
+    private function parseHttpStatus(array $headers): ?int
+    {
+        if ([] === $headers) {
+            return null;
+        }
+
+        $statusLine = $headers[0];
+        if (1 !== preg_match('#^HTTP/\d+\.?\d*\s+(\d{3})#', $statusLine, $matches)) {
+            return null;
+        }
+
+        return (int) $matches[1];
+    }
+
+    private function trimSnippet(string $body, int $maxLength): string
+    {
+        $trimmed = trim($body);
+        if (\strlen($trimmed) <= $maxLength) {
+            return $trimmed;
+        }
+
+        return substr($trimmed, 0, $maxLength).'...';
+    }
+}

--- a/src/Tui/Scenarios/Transport/ScenarioTransport.php
+++ b/src/Tui/Scenarios/Transport/ScenarioTransport.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Scenarios\Transport;
+
+use App\Tui\Scenarios\ScenarioResult;
+
+interface ScenarioTransport
+{
+    /**
+     * @param array<string,mixed>|null $body
+     */
+    public function send(string $method, string $url, ?array $body): ScenarioResult;
+}

--- a/src/Tui/Scenarios/Validation/OutboundOpenApiValidatorFactory.php
+++ b/src/Tui/Scenarios/Validation/OutboundOpenApiValidatorFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Scenarios\Validation;
+
+use App\Simulator\Validation\OpenApiSpecNotFoundException;
+use App\Tui\Scenarios\DeviceBaseUrl;
+use cebe\openapi\Reader;
+use cebe\openapi\ReferenceContext;
+use cebe\openapi\spec\OpenApi;
+use cebe\openapi\spec\Server;
+use League\OpenAPIValidation\PSR7\RequestValidator;
+use League\OpenAPIValidation\PSR7\ValidatorBuilder;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final class OutboundOpenApiValidatorFactory
+{
+    private const string OPENAPI_SPEC_RELATIVE_PATH = '/sync/openapi.yaml';
+
+    public function __construct(
+        #[Autowire('%kernel.project_dir%')]
+        private readonly string $projectDir,
+        #[Autowire('%env(default::PIXELCAST_DEVICE_BASE_URL)%')]
+        private readonly ?string $deviceBaseUrl = null,
+    ) {
+    }
+
+    public function create(): RequestValidator
+    {
+        $specPath = $this->projectDir.self::OPENAPI_SPEC_RELATIVE_PATH;
+
+        if (!is_file($specPath)) {
+            throw OpenApiSpecNotFoundException::forPath($specPath);
+        }
+
+        $openApi = Reader::readFromYamlFile(
+            $specPath,
+            OpenApi::class,
+            ReferenceContext::RESOLVE_MODE_ALL,
+        );
+
+        // Spec advertises http://pixelcast.local/api; outbound calls target the configured device, so override servers.
+        $openApi->servers = [new Server(['url' => DeviceBaseUrl::resolve($this->deviceBaseUrl)])];
+
+        return new ValidatorBuilder()
+            ->fromSchema($openApi)
+            ->getRequestValidator();
+    }
+}

--- a/src/Tui/Scenarios/Validation/OutboundPayloadValidator.php
+++ b/src/Tui/Scenarios/Validation/OutboundPayloadValidator.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Scenarios\Validation;
+
+use App\Simulator\Validation\ValidationResult;
+use App\Tui\Scenarios\DeviceBaseUrl;
+use App\Tui\Scenarios\ScenarioDefinition;
+use League\OpenAPIValidation\PSR7\Exception\ValidationFailed;
+use League\OpenAPIValidation\PSR7\RequestValidator;
+use Nyholm\Psr7\Request;
+use Psr\Http\Message\StreamFactoryInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class OutboundPayloadValidator
+{
+    public function __construct(
+        private RequestValidator $validator,
+        private StreamFactoryInterface $streamFactory,
+        #[Autowire('%env(default::PIXELCAST_DEVICE_BASE_URL)%')]
+        private ?string $deviceBaseUrl = null,
+    ) {
+    }
+
+    public function validate(ScenarioDefinition $scenario): ValidationResult
+    {
+        $psrRequest = $this->buildPsrRequest($scenario);
+
+        try {
+            $this->validator->validate($psrRequest);
+        } catch (ValidationFailed $validationFailed) {
+            return ValidationResult::failure($this->formatErrorMessage($validationFailed));
+        }
+
+        return ValidationResult::success();
+    }
+
+    private function buildPsrRequest(ScenarioDefinition $scenario): Request
+    {
+        $baseUrl = DeviceBaseUrl::resolve($this->deviceBaseUrl);
+        $uri = rtrim($baseUrl, '/').$scenario->path;
+
+        if ([] !== $scenario->queryParams) {
+            $uri .= '?'.http_build_query($scenario->queryParams);
+        }
+
+        $headers = [];
+        $body = null;
+
+        if (null !== $scenario->body) {
+            $headers['Content-Type'] = 'application/json';
+            $body = $this->streamFactory->createStream(
+                json_encode($scenario->body, \JSON_THROW_ON_ERROR),
+            );
+        }
+
+        return new Request($scenario->httpMethod, $uri, $headers, $body);
+    }
+
+    private function formatErrorMessage(ValidationFailed $validationFailed): string
+    {
+        $message = $validationFailed->getMessage();
+        $previous = $validationFailed->getPrevious();
+
+        if ($previous instanceof \Throwable) {
+            return $message.'; cause: '.$previous->getMessage();
+        }
+
+        return $message;
+    }
+}

--- a/src/Tui/TerminalSafeText.php
+++ b/src/Tui/TerminalSafeText.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui;
+
+final class TerminalSafeText
+{
+    public static function stripControlBytes(string $value): string
+    {
+        return preg_replace("/[\x00-\x08\x0b-\x1f\x7f]|\xc2[\x80-\x9f]/", '', $value) ?? '';
+    }
+}

--- a/tests/Command/TuiCommandWiringTest.php
+++ b/tests/Command/TuiCommandWiringTest.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace App\Tests\Command;
 
 use App\Command\TuiCommand;
+use App\Tui\Scenarios\ScenarioCatalog;
+use App\Tui\Scenarios\ScenarioDispatcher;
+use App\Tui\Scenarios\Transport\ScenarioHttpClient;
+use App\Tui\Scenarios\Validation\OutboundPayloadValidator;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class TuiCommandWiringTest extends KernelTestCase
@@ -16,5 +20,41 @@ final class TuiCommandWiringTest extends KernelTestCase
         $command = self::getContainer()->get(TuiCommand::class);
 
         self::assertInstanceOf(TuiCommand::class, $command);
+    }
+
+    public function testScenarioCatalogResolvesFromContainer(): void
+    {
+        self::bootKernel();
+
+        $catalog = self::getContainer()->get(ScenarioCatalog::class);
+
+        self::assertInstanceOf(ScenarioCatalog::class, $catalog);
+    }
+
+    public function testOutboundPayloadValidatorResolvesFromContainer(): void
+    {
+        self::bootKernel();
+
+        $validator = self::getContainer()->get(OutboundPayloadValidator::class);
+
+        self::assertInstanceOf(OutboundPayloadValidator::class, $validator);
+    }
+
+    public function testScenarioDispatcherResolvesFromContainer(): void
+    {
+        self::bootKernel();
+
+        $dispatcher = self::getContainer()->get(ScenarioDispatcher::class);
+
+        self::assertInstanceOf(ScenarioDispatcher::class, $dispatcher);
+    }
+
+    public function testScenarioHttpClientResolvesFromContainer(): void
+    {
+        self::bootKernel();
+
+        $httpClient = self::getContainer()->get(ScenarioHttpClient::class);
+
+        self::assertInstanceOf(ScenarioHttpClient::class, $httpClient);
     }
 }

--- a/tests/Tui/Scenarios/Panel/ScenariosPanelTest.php
+++ b/tests/Tui/Scenarios/Panel/ScenariosPanelTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Scenarios\Panel;
+
+use App\Tui\Scenarios\Panel\ScenariosPanel;
+use App\Tui\Scenarios\ScenarioCatalog;
+use App\Tui\Scenarios\ScenarioResult;
+use App\Tui\TuiMode;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\SelectListWidget;
+
+final class ScenariosPanelTest extends TestCase
+{
+    private ScenariosPanel $panel;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->panel = new ScenariosPanel(new ScenarioCatalog(), TuiMode::Dev);
+    }
+
+    public function testWidgetIsContainerAndInitialResultIsEmpty(): void
+    {
+        self::assertInstanceOf(ContainerWidget::class, $this->panel->widget());
+        self::assertInstanceOf(SelectListWidget::class, $this->panel->selectListWidget());
+        self::assertSame('', $this->panel->currentResultText());
+    }
+
+    public function testSelectListIsPrePopulatedWithCatalogEntries(): void
+    {
+        $selected = $this->panel->selectListWidget()->getSelectedItem();
+
+        self::assertNotNull($selected);
+        self::assertSame('weather', $selected['value']);
+    }
+
+    public function testShowResultFormatsSuccessWithStatusOnlyWhenMessageIsDefault(): void
+    {
+        $this->panel->showResult(ScenarioResult::success(204));
+
+        self::assertSame('OK 204', $this->panel->currentResultText());
+    }
+
+    public function testShowResultFormatsSuccessWithMessageAppendedWhenInformative(): void
+    {
+        $this->panel->showResult(ScenarioResult::success(201, 'created'));
+
+        self::assertSame('OK 201: created', $this->panel->currentResultText());
+    }
+
+    public function testShowResultFormatsValidationFailure(): void
+    {
+        $this->panel->showResult(ScenarioResult::validationFailure('text is required'));
+
+        self::assertSame('VALIDATION text is required', $this->panel->currentResultText());
+    }
+
+    public function testShowResultFormatsTransportFailureWithHttpStatus(): void
+    {
+        $this->panel->showResult(ScenarioResult::transportFailure('server error', 500));
+
+        self::assertSame('FAIL HTTP 500: server error', $this->panel->currentResultText());
+    }
+
+    public function testShowResultFormatsTransportFailureWithoutHttpStatus(): void
+    {
+        $this->panel->showResult(ScenarioResult::transportFailure('Transport error: boom'));
+
+        self::assertSame('FAIL Transport error: boom', $this->panel->currentResultText());
+    }
+
+    public function testShowResultFormatsUnreachable(): void
+    {
+        $this->panel->showResult(ScenarioResult::unreachable('connection refused'));
+
+        self::assertSame('UNREACHABLE connection refused', $this->panel->currentResultText());
+    }
+
+    public function testShowResultStripsControlBytesFromMessage(): void
+    {
+        $this->panel->showResult(ScenarioResult::unreachable("conn\x1b[2J refused"));
+
+        self::assertSame('UNREACHABLE conn[2J refused', $this->panel->currentResultText());
+    }
+
+    public function testClearResultEmptiesTheResultLine(): void
+    {
+        $this->panel->showResult(ScenarioResult::success(200));
+
+        $this->panel->clearResult();
+
+        self::assertSame('', $this->panel->currentResultText());
+    }
+}

--- a/tests/Tui/Scenarios/ScenarioCatalogTest.php
+++ b/tests/Tui/Scenarios/ScenarioCatalogTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Scenarios;
+
+use App\Tui\Scenarios\ScenarioCatalog;
+use App\Tui\Scenarios\ScenarioDefinition;
+use App\Tui\TuiMode;
+use PHPUnit\Framework\TestCase;
+
+final class ScenarioCatalogTest extends TestCase
+{
+    public function testDevModeReturnsFourteenScenarios(): void
+    {
+        $catalog = new ScenarioCatalog();
+
+        self::assertCount(14, $catalog->all(TuiMode::Dev));
+    }
+
+    public function testProdModeOmitsResetScenarioAndReturnsThirteen(): void
+    {
+        $catalog = new ScenarioCatalog();
+
+        $scenarios = $catalog->all(TuiMode::Prod);
+
+        self::assertCount(13, $scenarios);
+        $ids = array_map(static fn (ScenarioDefinition $scenario): string => $scenario->id, $scenarios);
+        self::assertNotContains('reset-simulator', $ids);
+    }
+
+    public function testAllScenarioIdsAreUnique(): void
+    {
+        $catalog = new ScenarioCatalog();
+
+        $ids = array_map(
+            static fn (ScenarioDefinition $scenario): string => $scenario->id,
+            $catalog->all(TuiMode::Dev),
+        );
+
+        self::assertSame($ids, array_values(array_unique($ids)));
+    }
+
+    public function testOrderMatchesMockupForDevAndProd(): void
+    {
+        $catalog = new ScenarioCatalog();
+
+        $devIds = array_map(
+            static fn (ScenarioDefinition $scenario): string => $scenario->id,
+            $catalog->all(TuiMode::Dev),
+        );
+        $prodIds = array_map(
+            static fn (ScenarioDefinition $scenario): string => $scenario->id,
+            $catalog->all(TuiMode::Prod),
+        );
+
+        self::assertSame('weather', $devIds[0]);
+        self::assertSame('reset-simulator', end($devIds));
+
+        self::assertSame('weather', $prodIds[0]);
+        self::assertSame('icon-register', end($prodIds));
+    }
+
+    public function testResetScenarioHasNoBody(): void
+    {
+        $catalog = new ScenarioCatalog();
+
+        $resetScenario = $catalog->findById('reset-simulator', TuiMode::Dev);
+
+        self::assertNotNull($resetScenario);
+        self::assertNull($resetScenario->body);
+        self::assertSame('/__reset', $resetScenario->path);
+    }
+
+    public function testFindByIdReturnsMatchingScenarioInDev(): void
+    {
+        $catalog = new ScenarioCatalog();
+
+        $scenario = $catalog->findById('weather', TuiMode::Dev);
+
+        self::assertNotNull($scenario);
+        self::assertSame('weather', $scenario->id);
+        self::assertSame('Weather', $scenario->label);
+    }
+
+    public function testFindByIdReturnsNullForResetInProdMode(): void
+    {
+        $catalog = new ScenarioCatalog();
+
+        self::assertNull($catalog->findById('reset-simulator', TuiMode::Prod));
+    }
+
+    public function testFindByIdReturnsNullForUnknownId(): void
+    {
+        $catalog = new ScenarioCatalog();
+
+        self::assertNull($catalog->findById('nope', TuiMode::Dev));
+    }
+}

--- a/tests/Tui/Scenarios/ScenarioDefinitionTest.php
+++ b/tests/Tui/Scenarios/ScenarioDefinitionTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Scenarios;
+
+use App\Tui\Scenarios\ScenarioDefinition;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ScenarioDefinitionTest extends TestCase
+{
+    public function testConstructorStoresEveryFieldVerbatim(): void
+    {
+        $scenario = new ScenarioDefinition(
+            id: 'weather',
+            label: 'Weather',
+            description: 'current conditions + 3-day forecast',
+            httpMethod: 'POST',
+            path: '/weather',
+            queryParams: ['name' => 'BTC'],
+            body: ['temp' => 22],
+        );
+
+        self::assertSame('weather', $scenario->id);
+        self::assertSame('Weather', $scenario->label);
+        self::assertSame('current conditions + 3-day forecast', $scenario->description);
+        self::assertSame('POST', $scenario->httpMethod);
+        self::assertSame('/weather', $scenario->path);
+        self::assertSame(['name' => 'BTC'], $scenario->queryParams);
+        self::assertSame(['temp' => 22], $scenario->body);
+    }
+
+    public function testDefaultValuesAreAppliedWhenOptionalArgumentsOmitted(): void
+    {
+        $scenario = new ScenarioDefinition(
+            id: 'brightness',
+            label: 'Brightness',
+            description: 'set device brightness',
+            httpMethod: 'POST',
+            path: '/brightness',
+        );
+
+        self::assertSame([], $scenario->queryParams);
+        self::assertNull($scenario->body);
+    }
+
+    /**
+     * @return iterable<string,array{string,string,string}>
+     */
+    public static function provideEmptyRequiredFieldCases(): iterable
+    {
+        yield 'empty id' => ['', 'Weather', '/weather'];
+        yield 'empty label' => ['weather', '', '/weather'];
+        yield 'empty path' => ['weather', 'Weather', ''];
+    }
+
+    #[DataProvider('provideEmptyRequiredFieldCases')]
+    public function testConstructorRejectsEmptyRequiredField(string $id, string $label, string $path): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new ScenarioDefinition(
+            id: $id,
+            label: $label,
+            description: 'some description',
+            httpMethod: 'POST',
+            path: $path,
+        );
+    }
+
+    public function testConstructorRejectsUnknownHttpMethod(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('WHATEVER');
+
+        new ScenarioDefinition(
+            id: 'weather',
+            label: 'Weather',
+            description: 'current conditions',
+            httpMethod: 'WHATEVER',
+            path: '/weather',
+        );
+    }
+}

--- a/tests/Tui/Scenarios/ScenarioDispatcherTest.php
+++ b/tests/Tui/Scenarios/ScenarioDispatcherTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Scenarios;
+
+use App\Tui\Scenarios\ScenarioCatalog;
+use App\Tui\Scenarios\ScenarioDefinition;
+use App\Tui\Scenarios\ScenarioDispatcher;
+use App\Tui\Scenarios\ScenarioResult;
+use App\Tui\Scenarios\Transport\ScenarioTransport;
+use App\Tui\Scenarios\Validation\OutboundOpenApiValidatorFactory;
+use App\Tui\Scenarios\Validation\OutboundPayloadValidator;
+use App\Tui\TuiMode;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class ScenarioDispatcherTest extends TestCase
+{
+    private const string TEST_DEVICE_BASE_URL = 'http://simulator:8080';
+
+    private OutboundPayloadValidator $validator;
+    private ScenarioCatalog $catalog;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $projectDir = \dirname(__DIR__, 3);
+
+        $factory = new OutboundOpenApiValidatorFactory($projectDir, self::TEST_DEVICE_BASE_URL);
+        $this->validator = new OutboundPayloadValidator(
+            $factory->create(),
+            new Psr17Factory(),
+            self::TEST_DEVICE_BASE_URL,
+        );
+        $this->catalog = new ScenarioCatalog();
+    }
+
+    public function testValidationFailureShortCircuitsAndDoesNotCallTransport(): void
+    {
+        $invalidNotification = new ScenarioDefinition(
+            id: 'notification-invalid',
+            label: 'Notification - missing text',
+            description: 'invalid: required text field stripped',
+            httpMethod: 'POST',
+            path: '/notify',
+            body: ['icon' => 'mail'],
+        );
+
+        $transport = new CapturingScenarioTransportStub(ScenarioResult::success(200, 'OK 200'));
+        $dispatcher = new ScenarioDispatcher($this->validator, $transport, self::TEST_DEVICE_BASE_URL);
+
+        $result = $dispatcher->dispatch($invalidNotification);
+
+        self::assertFalse($result->success);
+        self::assertNull($result->httpStatus);
+        self::assertSame([], $transport->calls);
+    }
+
+    public function testResetScenarioBypassesValidationAndCallsTransportOnce(): void
+    {
+        $reset = $this->catalog->findById('reset-simulator', TuiMode::Dev);
+        self::assertNotNull($reset);
+
+        $transport = new CapturingScenarioTransportStub(ScenarioResult::success(200, 'OK 200'));
+        $dispatcher = new ScenarioDispatcher($this->validator, $transport, self::TEST_DEVICE_BASE_URL);
+
+        $result = $dispatcher->dispatch($reset);
+
+        self::assertTrue($result->success);
+        self::assertSame(200, $result->httpStatus);
+        self::assertCount(1, $transport->calls);
+        self::assertSame('POST', $transport->calls[0]['method']);
+        self::assertStringEndsWith('/__reset', $transport->calls[0]['url']);
+        self::assertNull($transport->calls[0]['body']);
+    }
+
+    public function testWeatherScenarioValidatesAndPostsPayloadToWeatherEndpoint(): void
+    {
+        $weather = $this->catalog->findById('weather', TuiMode::Dev);
+        self::assertNotNull($weather);
+
+        $transport = new CapturingScenarioTransportStub(ScenarioResult::success(200, 'OK 200'));
+        $dispatcher = new ScenarioDispatcher($this->validator, $transport, self::TEST_DEVICE_BASE_URL);
+
+        $result = $dispatcher->dispatch($weather);
+
+        self::assertTrue($result->success);
+        self::assertSame(200, $result->httpStatus);
+        self::assertCount(1, $transport->calls);
+        self::assertSame('POST', $transport->calls[0]['method']);
+        self::assertStringEndsWith('/weather', $transport->calls[0]['url']);
+        self::assertSame($weather->body, $transport->calls[0]['body']);
+    }
+
+    public function testTrackerScenarioBuildsUrlWithQueryString(): void
+    {
+        $tracker = $this->catalog->findById('tracker-btc', TuiMode::Dev);
+        self::assertNotNull($tracker);
+
+        $transport = new CapturingScenarioTransportStub(ScenarioResult::success(200, 'OK 200'));
+        $dispatcher = new ScenarioDispatcher($this->validator, $transport, self::TEST_DEVICE_BASE_URL);
+
+        $result = $dispatcher->dispatch($tracker);
+
+        self::assertTrue($result->success);
+        self::assertCount(1, $transport->calls);
+        self::assertStringContainsString('/tracker?name=BTC', $transport->calls[0]['url']);
+    }
+
+    public function testTransportExceptionIsConvertedToTransportFailure(): void
+    {
+        $weather = $this->catalog->findById('weather', TuiMode::Dev);
+        self::assertNotNull($weather);
+
+        $throwingTransport = new ThrowingScenarioTransportStub(new \RuntimeException('boom'));
+        $dispatcher = new ScenarioDispatcher($this->validator, $throwingTransport, self::TEST_DEVICE_BASE_URL);
+
+        $result = $dispatcher->dispatch($weather);
+
+        self::assertFalse($result->success);
+        self::assertNull($result->httpStatus);
+        self::assertStringContainsString('boom', $result->message);
+    }
+}
+
+final class CapturingScenarioTransportStub implements ScenarioTransport
+{
+    /**
+     * @var list<array{method: string, url: string, body: array<string,mixed>|null}>
+     */
+    public array $calls = [];
+
+    public function __construct(
+        private readonly ScenarioResult $resultToReturn,
+    ) {
+    }
+
+    public function send(string $method, string $url, ?array $body): ScenarioResult
+    {
+        $this->calls[] = [
+            'method' => $method,
+            'url' => $url,
+            'body' => $body,
+        ];
+
+        return $this->resultToReturn;
+    }
+}
+
+final class ThrowingScenarioTransportStub implements ScenarioTransport
+{
+    public function __construct(
+        private readonly \Throwable $exceptionToThrow,
+    ) {
+    }
+
+    public function send(string $method, string $url, ?array $body): ScenarioResult
+    {
+        throw $this->exceptionToThrow;
+    }
+}

--- a/tests/Tui/Scenarios/Transport/ScenarioHttpClientTest.php
+++ b/tests/Tui/Scenarios/Transport/ScenarioHttpClientTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Scenarios\Transport;
+
+use App\Tui\Scenarios\Transport\ScenarioHttpClient;
+use PHPUnit\Framework\TestCase;
+
+final class ScenarioHttpClientTest extends TestCase
+{
+    public function testSendReturnsUnreachableWhenHostIsUnroutable(): void
+    {
+        $client = new ScenarioHttpClient();
+
+        $result = $client->send('POST', 'http://127.0.0.1:1/__reset', null);
+
+        self::assertFalse($result->success);
+        self::assertNull($result->httpStatus);
+        self::assertNotSame('', $result->message);
+    }
+}

--- a/tests/Tui/Scenarios/Validation/OutboundPayloadValidatorTest.php
+++ b/tests/Tui/Scenarios/Validation/OutboundPayloadValidatorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Scenarios\Validation;
+
+use App\Tui\Scenarios\ScenarioCatalog;
+use App\Tui\Scenarios\ScenarioDefinition;
+use App\Tui\Scenarios\Validation\OutboundOpenApiValidatorFactory;
+use App\Tui\Scenarios\Validation\OutboundPayloadValidator;
+use App\Tui\TuiMode;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class OutboundPayloadValidatorTest extends KernelTestCase
+{
+    private const string TEST_DEVICE_BASE_URL = 'http://simulator:8080';
+
+    private OutboundPayloadValidator $validator;
+    private ScenarioCatalog $catalog;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $projectDir = self::getContainer()->getParameter('kernel.project_dir');
+
+        $factory = new OutboundOpenApiValidatorFactory($projectDir, self::TEST_DEVICE_BASE_URL);
+        $this->validator = new OutboundPayloadValidator(
+            $factory->create(),
+            new Psr17Factory(),
+            self::TEST_DEVICE_BASE_URL,
+        );
+        $this->catalog = new ScenarioCatalog();
+    }
+
+    public function testWeatherScenarioPayloadValidatesAgainstSpec(): void
+    {
+        $weather = $this->catalog->findById('weather', TuiMode::Dev);
+        self::assertNotNull($weather);
+
+        $result = $this->validator->validate($weather);
+
+        self::assertTrue($result->valid, $result->errorMessage ?? '');
+        self::assertNull($result->errorMessage);
+    }
+
+    public function testTrackerScenarioWithQueryStringValidatesAgainstSpec(): void
+    {
+        $tracker = $this->catalog->findById('tracker-btc', TuiMode::Dev);
+        self::assertNotNull($tracker);
+
+        $result = $this->validator->validate($tracker);
+
+        self::assertTrue($result->valid, $result->errorMessage ?? '');
+    }
+
+    public function testIconRegisterScenarioPayloadValidatesAgainstSpec(): void
+    {
+        $iconRegister = $this->catalog->findById('icon-register', TuiMode::Dev);
+        self::assertNotNull($iconRegister);
+
+        $result = $this->validator->validate($iconRegister);
+
+        self::assertTrue($result->valid, $result->errorMessage ?? '');
+    }
+
+    public function testNotificationMissingRequiredTextFailsValidation(): void
+    {
+        $invalidNotification = new ScenarioDefinition(
+            id: 'notification-invalid',
+            label: 'Notification - missing text',
+            description: 'invalid: required text field stripped',
+            httpMethod: 'POST',
+            path: '/notify',
+            body: ['icon' => 'mail'],
+        );
+
+        $result = $this->validator->validate($invalidNotification);
+
+        self::assertFalse($result->valid);
+        self::assertNotNull($result->errorMessage);
+        self::assertStringContainsStringIgnoringCase('text', $result->errorMessage);
+    }
+}


### PR DESCRIPTION
## Summary

Plugs the `[1] Scenarios` sub-view into `app:tui`. Each entry dispatches a predefined REST call (Weather, Trackers x3, Notifications x2, Custom App, Indicators x3, Brightness, Settings, Icon register, Reset) to the configured ESP32 target — simulator in dev, real device in prod. Every payload is first validated against `sync/openapi.yaml` (AC-ARCH-5); invalid payloads show inline as `VALIDATION <error>` and skip the HTTP call.

The validation gate is bound to a path whitelist (`PATHS_OUTSIDE_OPENAPI_SPEC = ['/__reset']`) rather than a per-scenario flag, so future scenarios cannot accidentally bypass it.

Closes #30