### PR TITLE
feat(tui): add Sync Now + Reset Sim dev panels (#31)

### DIFF
--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -123,28 +123,17 @@ final class TuiCommand extends Command
             ));
         }
 
-        $tui->addListener(function (SelectEvent $event) use ($tui, $menuSelectList, $viewContainer, $viewWidgets, $syncNowPanel, $resetSimPanel): void {
+        $tui->addListener(function (SelectEvent $event) use ($tui, $menuSelectList, $viewContainer, $viewWidgets): void {
             if ($event->getTarget() !== $menuSelectList) {
                 return;
             }
 
-            $menuValue = $event->getValue();
-
-            if ('scenarios' === $menuValue) {
-                $this->switchView($tui, $viewContainer, TuiView::Scenarios, $viewWidgets);
-
+            $targetView = TuiView::tryFrom($event->getValue());
+            if (null === $targetView || !isset($viewWidgets[$targetView->value])) {
                 return;
             }
 
-            if ('sync-now' === $menuValue && null !== $syncNowPanel) {
-                $this->switchView($tui, $viewContainer, TuiView::SyncNow, $viewWidgets);
-
-                return;
-            }
-
-            if ('reset-sim' === $menuValue && null !== $resetSimPanel) {
-                $this->switchView($tui, $viewContainer, TuiView::ResetSim, $viewWidgets);
-            }
+            $this->switchView($tui, $viewContainer, $targetView, $viewWidgets);
         });
 
         $tui->addListener(function (SelectEvent $event) use ($tui, $scenariosPanel, $mode): void {

--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -11,6 +11,8 @@ use App\Tui\Inspector\StateInspectorPanel;
 use App\Tui\Menu\TuiMenuFactory;
 use App\Tui\Reachability\DeviceReachabilityProbe;
 use App\Tui\Reachability\DeviceReachabilityResult;
+use App\Tui\ResetSim\Panel\ResetSimPanel;
+use App\Tui\ResetSim\ResetSimulatorAction;
 use App\Tui\Scenarios\Panel\ScenariosPanel;
 use App\Tui\Scenarios\ScenarioCatalog;
 use App\Tui\Scenarios\ScenarioDispatcher;
@@ -50,6 +52,7 @@ final class TuiCommand extends Command
         private readonly ScenarioCatalog $scenarioCatalog,
         private readonly ScenarioDispatcher $scenarioDispatcher,
         private readonly SyncNowDispatcher $syncNowDispatcher,
+        private readonly ResetSimulatorAction $resetSimulatorAction,
     ) {
         parent::__construct();
     }
@@ -87,8 +90,10 @@ final class TuiCommand extends Command
         $scenariosPanel = new ScenariosPanel($this->scenarioCatalog, $mode);
 
         $syncNowPanel = null;
+        $resetSimPanel = null;
         if (TuiMode::Dev === $mode) {
             $syncNowPanel = new SyncNowPanel();
+            $resetSimPanel = new ResetSimPanel();
         }
 
         $viewContainer = new ContainerWidget();
@@ -107,7 +112,7 @@ final class TuiCommand extends Command
             ));
         }
 
-        $tui->addListener(function (SelectEvent $event) use ($tui, $menuSelectList, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel): void {
+        $tui->addListener(function (SelectEvent $event) use ($tui, $menuSelectList, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel): void {
             if ($event->getTarget() !== $menuSelectList) {
                 return;
             }
@@ -115,13 +120,19 @@ final class TuiCommand extends Command
             $menuValue = $event->getValue();
 
             if ('scenarios' === $menuValue) {
-                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, TuiView::Scenarios);
+                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel, TuiView::Scenarios);
 
                 return;
             }
 
             if ('sync-now' === $menuValue && null !== $syncNowPanel) {
-                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, TuiView::SyncNow);
+                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel, TuiView::SyncNow);
+
+                return;
+            }
+
+            if ('reset-sim' === $menuValue && null !== $resetSimPanel) {
+                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel, TuiView::ResetSim);
             }
         });
 
@@ -140,13 +151,13 @@ final class TuiCommand extends Command
             $tui->requestRender();
         });
 
-        $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel): void {
+        $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel): void {
             if ($event->getTarget() !== $scenariosPanel->selectListWidget()) {
                 return;
             }
 
             $scenariosPanel->clearResult();
-            $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, TuiView::Main);
+            $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel, TuiView::Main);
         });
 
         if (null !== $syncNowPanel) {
@@ -168,13 +179,34 @@ final class TuiCommand extends Command
                 $tui->requestRender();
             });
 
-            $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel): void {
+            $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel): void {
                 if ($event->getTarget() !== $syncNowPanel->selectListWidget()) {
                     return;
                 }
 
                 $syncNowPanel->clearResult();
-                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, TuiView::Main);
+                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel, TuiView::Main);
+            });
+        }
+
+        if (null !== $resetSimPanel) {
+            $tui->addListener(function (SelectEvent $event) use ($tui, $resetSimPanel): void {
+                if ($event->getTarget() !== $resetSimPanel->selectListWidget()) {
+                    return;
+                }
+
+                $result = $this->resetSimulatorAction->reset();
+                $resetSimPanel->showResult($result);
+                $tui->requestRender();
+            });
+
+            $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel): void {
+                if ($event->getTarget() !== $resetSimPanel->selectListWidget()) {
+                    return;
+                }
+
+                $resetSimPanel->clearResult();
+                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel, TuiView::Main);
             });
         }
 
@@ -199,6 +231,7 @@ final class TuiCommand extends Command
         ContainerWidget $mainBodyContainer,
         ScenariosPanel $scenariosPanel,
         ?SyncNowPanel $syncNowPanel,
+        ?ResetSimPanel $resetSimPanel,
         TuiView $next,
     ): void {
         if ($this->currentView === $next) {
@@ -209,6 +242,7 @@ final class TuiCommand extends Command
             TuiView::Main => $mainBodyContainer,
             TuiView::Scenarios => $scenariosPanel->widget(),
             TuiView::SyncNow => $syncNowPanel?->widget(),
+            TuiView::ResetSim => $resetSimPanel?->widget(),
         };
 
         if (null === $nextWidget) {

--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -103,6 +103,17 @@ final class TuiCommand extends Command
         $tui->add($viewContainer);
         $tui->add($this->buildStatusBarWidget($mode, $reachabilityResult));
 
+        $viewWidgets = [
+            TuiView::Main->value => $mainBodyContainer,
+            TuiView::Scenarios->value => $scenariosPanel->widget(),
+        ];
+        if (null !== $syncNowPanel) {
+            $viewWidgets[TuiView::SyncNow->value] = $syncNowPanel->widget();
+        }
+        if (null !== $resetSimPanel) {
+            $viewWidgets[TuiView::ResetSim->value] = $resetSimPanel->widget();
+        }
+
         if (null !== $inspectorPoller) {
             $tui->onTick($this->buildInspectorTickListener(
                 $tui,
@@ -112,7 +123,7 @@ final class TuiCommand extends Command
             ));
         }
 
-        $tui->addListener(function (SelectEvent $event) use ($tui, $menuSelectList, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel): void {
+        $tui->addListener(function (SelectEvent $event) use ($tui, $menuSelectList, $viewContainer, $viewWidgets, $syncNowPanel, $resetSimPanel): void {
             if ($event->getTarget() !== $menuSelectList) {
                 return;
             }
@@ -120,19 +131,19 @@ final class TuiCommand extends Command
             $menuValue = $event->getValue();
 
             if ('scenarios' === $menuValue) {
-                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel, TuiView::Scenarios);
+                $this->switchView($tui, $viewContainer, TuiView::Scenarios, $viewWidgets);
 
                 return;
             }
 
             if ('sync-now' === $menuValue && null !== $syncNowPanel) {
-                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel, TuiView::SyncNow);
+                $this->switchView($tui, $viewContainer, TuiView::SyncNow, $viewWidgets);
 
                 return;
             }
 
             if ('reset-sim' === $menuValue && null !== $resetSimPanel) {
-                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel, TuiView::ResetSim);
+                $this->switchView($tui, $viewContainer, TuiView::ResetSim, $viewWidgets);
             }
         });
 
@@ -151,13 +162,13 @@ final class TuiCommand extends Command
             $tui->requestRender();
         });
 
-        $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel): void {
+        $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $viewWidgets, $scenariosPanel): void {
             if ($event->getTarget() !== $scenariosPanel->selectListWidget()) {
                 return;
             }
 
             $scenariosPanel->clearResult();
-            $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel, TuiView::Main);
+            $this->switchView($tui, $viewContainer, TuiView::Main, $viewWidgets);
         });
 
         if (null !== $syncNowPanel) {
@@ -179,13 +190,13 @@ final class TuiCommand extends Command
                 $tui->requestRender();
             });
 
-            $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel): void {
+            $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $viewWidgets, $syncNowPanel): void {
                 if ($event->getTarget() !== $syncNowPanel->selectListWidget()) {
                     return;
                 }
 
                 $syncNowPanel->clearResult();
-                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel, TuiView::Main);
+                $this->switchView($tui, $viewContainer, TuiView::Main, $viewWidgets);
             });
         }
 
@@ -200,13 +211,13 @@ final class TuiCommand extends Command
                 $tui->requestRender();
             });
 
-            $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel): void {
+            $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $viewWidgets, $resetSimPanel): void {
                 if ($event->getTarget() !== $resetSimPanel->selectListWidget()) {
                     return;
                 }
 
                 $resetSimPanel->clearResult();
-                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, $resetSimPanel, TuiView::Main);
+                $this->switchView($tui, $viewContainer, TuiView::Main, $viewWidgets);
             });
         }
 
@@ -225,33 +236,26 @@ final class TuiCommand extends Command
         return Command::SUCCESS;
     }
 
+    /**
+     * @param array<string, AbstractWidget> $viewWidgets keyed by TuiView::value
+     */
     private function switchView(
         Tui $tui,
         ContainerWidget $viewContainer,
-        ContainerWidget $mainBodyContainer,
-        ScenariosPanel $scenariosPanel,
-        ?SyncNowPanel $syncNowPanel,
-        ?ResetSimPanel $resetSimPanel,
         TuiView $next,
+        array $viewWidgets,
     ): void {
         if ($this->currentView === $next) {
             return;
         }
 
-        $nextWidget = match ($next) {
-            TuiView::Main => $mainBodyContainer,
-            TuiView::Scenarios => $scenariosPanel->widget(),
-            TuiView::SyncNow => $syncNowPanel?->widget(),
-            TuiView::ResetSim => $resetSimPanel?->widget(),
-        };
-
-        if (null === $nextWidget) {
+        if (!isset($viewWidgets[$next->value])) {
             return;
         }
 
         $this->currentView = $next;
         $viewContainer->clear();
-        $viewContainer->add($nextWidget);
+        $viewContainer->add($viewWidgets[$next->value]);
 
         $tui->requestRender();
     }

--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -14,6 +14,10 @@ use App\Tui\Reachability\DeviceReachabilityResult;
 use App\Tui\Scenarios\Panel\ScenariosPanel;
 use App\Tui\Scenarios\ScenarioCatalog;
 use App\Tui\Scenarios\ScenarioDispatcher;
+use App\Tui\SyncNow\Panel\SyncNowPanel;
+use App\Tui\SyncNow\SyncNowDispatcher;
+use App\Tui\SyncNow\SyncNowResultKind;
+use App\Tui\SyncNow\SyncTarget;
 use App\Tui\TerminalSafeText;
 use App\Tui\TuiMode;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -45,6 +49,7 @@ final class TuiCommand extends Command
         private readonly InspectorTransport $inspectorHttpClient,
         private readonly ScenarioCatalog $scenarioCatalog,
         private readonly ScenarioDispatcher $scenarioDispatcher,
+        private readonly SyncNowDispatcher $syncNowDispatcher,
     ) {
         parent::__construct();
     }
@@ -81,6 +86,11 @@ final class TuiCommand extends Command
 
         $scenariosPanel = new ScenariosPanel($this->scenarioCatalog, $mode);
 
+        $syncNowPanel = null;
+        if (TuiMode::Dev === $mode) {
+            $syncNowPanel = new SyncNowPanel();
+        }
+
         $viewContainer = new ContainerWidget();
         $viewContainer->expandVertically(true);
         $viewContainer->add($mainBodyContainer);
@@ -97,15 +107,22 @@ final class TuiCommand extends Command
             ));
         }
 
-        $tui->addListener(function (SelectEvent $event) use ($tui, $menuSelectList, $viewContainer, $mainBodyContainer, $scenariosPanel): void {
+        $tui->addListener(function (SelectEvent $event) use ($tui, $menuSelectList, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel): void {
             if ($event->getTarget() !== $menuSelectList) {
                 return;
             }
-            if ('scenarios' !== $event->getValue()) {
+
+            $menuValue = $event->getValue();
+
+            if ('scenarios' === $menuValue) {
+                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, TuiView::Scenarios);
+
                 return;
             }
 
-            $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, TuiView::Scenarios);
+            if ('sync-now' === $menuValue && null !== $syncNowPanel) {
+                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, TuiView::SyncNow);
+            }
         });
 
         $tui->addListener(function (SelectEvent $event) use ($tui, $scenariosPanel, $mode): void {
@@ -123,14 +140,43 @@ final class TuiCommand extends Command
             $tui->requestRender();
         });
 
-        $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $mainBodyContainer, $scenariosPanel): void {
+        $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel): void {
             if ($event->getTarget() !== $scenariosPanel->selectListWidget()) {
                 return;
             }
 
             $scenariosPanel->clearResult();
-            $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, TuiView::Main);
+            $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, TuiView::Main);
         });
+
+        if (null !== $syncNowPanel) {
+            $tui->addListener(function (SelectEvent $event) use ($tui, $syncNowPanel): void {
+                if ($event->getTarget() !== $syncNowPanel->selectListWidget()) {
+                    return;
+                }
+
+                $target = SyncTarget::tryFrom($event->getValue());
+                if (null === $target) {
+                    return;
+                }
+
+                $result = $this->syncNowDispatcher->dispatch($target);
+                if (SyncNowResultKind::Dispatched === $result->kind) {
+                    $syncNowPanel->recordDispatch($target, new \DateTimeImmutable());
+                }
+                $syncNowPanel->showResult($result);
+                $tui->requestRender();
+            });
+
+            $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel): void {
+                if ($event->getTarget() !== $syncNowPanel->selectListWidget()) {
+                    return;
+                }
+
+                $syncNowPanel->clearResult();
+                $this->switchView($tui, $viewContainer, $mainBodyContainer, $scenariosPanel, $syncNowPanel, TuiView::Main);
+            });
+        }
 
         // Registered on the Tui (not on a widget) so Q quits before focus
         // routing, regardless of which sub-panel currently has focus.
@@ -152,18 +198,26 @@ final class TuiCommand extends Command
         ContainerWidget $viewContainer,
         ContainerWidget $mainBodyContainer,
         ScenariosPanel $scenariosPanel,
+        ?SyncNowPanel $syncNowPanel,
         TuiView $next,
     ): void {
         if ($this->currentView === $next) {
             return;
         }
 
-        $this->currentView = $next;
-        $viewContainer->clear();
-        $viewContainer->add(match ($next) {
+        $nextWidget = match ($next) {
             TuiView::Main => $mainBodyContainer,
             TuiView::Scenarios => $scenariosPanel->widget(),
-        });
+            TuiView::SyncNow => $syncNowPanel?->widget(),
+        };
+
+        if (null === $nextWidget) {
+            return;
+        }
+
+        $this->currentView = $next;
+        $viewContainer->clear();
+        $viewContainer->add($nextWidget);
 
         $tui->requestRender();
     }

--- a/src/Command/TuiView.php
+++ b/src/Command/TuiView.php
@@ -8,4 +8,5 @@ enum TuiView: string
 {
     case Main = 'main';
     case Scenarios = 'scenarios';
+    case SyncNow = 'sync-now';
 }

--- a/src/Command/TuiView.php
+++ b/src/Command/TuiView.php
@@ -9,4 +9,5 @@ enum TuiView: string
     case Main = 'main';
     case Scenarios = 'scenarios';
     case SyncNow = 'sync-now';
+    case ResetSim = 'reset-sim';
 }

--- a/src/Tui/ResetSim/Panel/ResetSimPanel.php
+++ b/src/Tui/ResetSim/Panel/ResetSimPanel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Tui\ResetSim\Panel;
 
 use App\Tui\Scenarios\ScenarioResult;
-use App\Tui\Scenarios\ScenarioResultKind;
+use App\Tui\Scenarios\ScenarioResultFormatter;
 use App\Tui\TerminalSafeText;
 use Symfony\Component\Tui\Widget\ContainerWidget;
 use Symfony\Component\Tui\Widget\SelectListWidget;
@@ -56,7 +56,7 @@ final class ResetSimPanel
 
     public function showResult(ScenarioResult $result): void
     {
-        $this->resultLine->setText(TerminalSafeText::stripControlBytes($this->formatResult($result)));
+        $this->resultLine->setText(TerminalSafeText::stripControlBytes(ScenarioResultFormatter::format($result)));
     }
 
     public function clearResult(): void
@@ -67,28 +67,5 @@ final class ResetSimPanel
     public function currentResultText(): string
     {
         return $this->resultLine->getText();
-    }
-
-    private function formatResult(ScenarioResult $result): string
-    {
-        return match ($result->kind) {
-            ScenarioResultKind::Success => $this->formatSuccess($result),
-            ScenarioResultKind::ValidationFailure => 'VALIDATION '.$result->message,
-            ScenarioResultKind::TransportFailure => null !== $result->httpStatus
-                ? \sprintf('FAIL HTTP %d: %s', $result->httpStatus, $result->message)
-                : 'FAIL '.$result->message,
-            ScenarioResultKind::Unreachable => 'UNREACHABLE '.$result->message,
-        };
-    }
-
-    private function formatSuccess(ScenarioResult $result): string
-    {
-        $statusOnly = 'OK '.($result->httpStatus ?? 0);
-
-        if ('' === $result->message || 'OK' === $result->message) {
-            return $statusOnly;
-        }
-
-        return $statusOnly.': '.$result->message;
     }
 }

--- a/src/Tui/ResetSim/Panel/ResetSimPanel.php
+++ b/src/Tui/ResetSim/Panel/ResetSimPanel.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\ResetSim\Panel;
+
+use App\Tui\Scenarios\ScenarioResult;
+use App\Tui\Scenarios\ScenarioResultKind;
+use App\Tui\TerminalSafeText;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\SelectListWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+
+final class ResetSimPanel
+{
+    private const string HEADER_TEXT = 'Reset Simulator - [Enter] confirm  [Esc] back';
+    private const string SEPARATOR_TEXT = '----------------------------------------------------------------';
+    private const string CONFIRM_ITEM_VALUE = 'reset';
+    private const string CONFIRM_ITEM_LABEL = '[Enter] POST /__reset';
+
+    private readonly TextWidget $resultLine;
+    private readonly SelectListWidget $list;
+    private readonly ContainerWidget $container;
+
+    public function __construct()
+    {
+        $items = [
+            [
+                'value' => self::CONFIRM_ITEM_VALUE,
+                'label' => self::CONFIRM_ITEM_LABEL,
+            ],
+        ];
+
+        $header = new TextWidget(self::HEADER_TEXT);
+        $separator = new TextWidget(self::SEPARATOR_TEXT);
+        $this->list = new SelectListWidget(items: $items, maxVisible: \count($items));
+        $this->resultLine = new TextWidget('');
+
+        $this->container = new ContainerWidget();
+        $this->container->expandVertically(true);
+        $this->container->add($header);
+        $this->container->add($separator);
+        $this->container->add($this->list);
+        $this->container->add($this->resultLine);
+    }
+
+    public function widget(): ContainerWidget
+    {
+        return $this->container;
+    }
+
+    public function selectListWidget(): SelectListWidget
+    {
+        return $this->list;
+    }
+
+    public function showResult(ScenarioResult $result): void
+    {
+        $this->resultLine->setText(TerminalSafeText::stripControlBytes($this->formatResult($result)));
+    }
+
+    public function clearResult(): void
+    {
+        $this->resultLine->setText('');
+    }
+
+    public function currentResultText(): string
+    {
+        return $this->resultLine->getText();
+    }
+
+    private function formatResult(ScenarioResult $result): string
+    {
+        return match ($result->kind) {
+            ScenarioResultKind::Success => $this->formatSuccess($result),
+            ScenarioResultKind::ValidationFailure => 'VALIDATION '.$result->message,
+            ScenarioResultKind::TransportFailure => null !== $result->httpStatus
+                ? \sprintf('FAIL HTTP %d: %s', $result->httpStatus, $result->message)
+                : 'FAIL '.$result->message,
+            ScenarioResultKind::Unreachable => 'UNREACHABLE '.$result->message,
+        };
+    }
+
+    private function formatSuccess(ScenarioResult $result): string
+    {
+        $statusOnly = 'OK '.($result->httpStatus ?? 0);
+
+        if ('' === $result->message || 'OK' === $result->message) {
+            return $statusOnly;
+        }
+
+        return $statusOnly.': '.$result->message;
+    }
+}

--- a/src/Tui/ResetSim/ResetSimulatorAction.php
+++ b/src/Tui/ResetSim/ResetSimulatorAction.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\ResetSim;
+
+use App\Tui\Scenarios\DeviceBaseUrl;
+use App\Tui\Scenarios\ScenarioResult;
+use App\Tui\Scenarios\Transport\ScenarioTransport;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class ResetSimulatorAction
+{
+    private const string RESET_PATH = '/__reset';
+
+    public function __construct(
+        private ScenarioTransport $transport,
+        #[Autowire('%env(default::PIXELCAST_DEVICE_BASE_URL)%')]
+        private ?string $deviceBaseUrl = null,
+    ) {
+    }
+
+    public function reset(): ScenarioResult
+    {
+        $baseUrl = DeviceBaseUrl::resolve($this->deviceBaseUrl);
+        $url = rtrim($baseUrl, '/').self::RESET_PATH;
+
+        try {
+            return $this->transport->send('POST', $url, null);
+        } catch (\Throwable $transportError) {
+            return ScenarioResult::transportFailure('Transport error: '.$transportError->getMessage());
+        }
+    }
+}

--- a/src/Tui/ResetSim/ResetSimulatorAction.php
+++ b/src/Tui/ResetSim/ResetSimulatorAction.php
@@ -4,31 +4,31 @@ declare(strict_types=1);
 
 namespace App\Tui\ResetSim;
 
-use App\Tui\Scenarios\DeviceBaseUrl;
+use App\Tui\Scenarios\ScenarioCatalog;
+use App\Tui\Scenarios\ScenarioDispatcher;
 use App\Tui\Scenarios\ScenarioResult;
-use App\Tui\Scenarios\Transport\ScenarioTransport;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use App\Tui\TuiMode;
 
 final readonly class ResetSimulatorAction
 {
-    private const string RESET_PATH = '/__reset';
+    private const string RESET_SCENARIO_ID = 'reset-simulator';
 
     public function __construct(
-        private ScenarioTransport $transport,
-        #[Autowire('%env(default::PIXELCAST_DEVICE_BASE_URL)%')]
-        private ?string $deviceBaseUrl = null,
+        private ScenarioCatalog $catalog,
+        private ScenarioDispatcher $dispatcher,
     ) {
     }
 
     public function reset(): ScenarioResult
     {
-        $baseUrl = DeviceBaseUrl::resolve($this->deviceBaseUrl);
-        $url = rtrim($baseUrl, '/').self::RESET_PATH;
+        $resetScenario = $this->catalog->findById(self::RESET_SCENARIO_ID, TuiMode::Dev);
 
-        try {
-            return $this->transport->send('POST', $url, null);
-        } catch (\Throwable $transportError) {
-            return ScenarioResult::transportFailure('Transport error: '.$transportError->getMessage());
+        if (null === $resetScenario) {
+            return ScenarioResult::transportFailure(
+                \sprintf('"%s" scenario missing from catalog', self::RESET_SCENARIO_ID),
+            );
         }
+
+        return $this->dispatcher->dispatch($resetScenario);
     }
 }

--- a/src/Tui/Scenarios/Panel/ScenariosPanel.php
+++ b/src/Tui/Scenarios/Panel/ScenariosPanel.php
@@ -6,7 +6,7 @@ namespace App\Tui\Scenarios\Panel;
 
 use App\Tui\Scenarios\ScenarioCatalog;
 use App\Tui\Scenarios\ScenarioResult;
-use App\Tui\Scenarios\ScenarioResultKind;
+use App\Tui\Scenarios\ScenarioResultFormatter;
 use App\Tui\TerminalSafeText;
 use App\Tui\TuiMode;
 use Symfony\Component\Tui\Widget\ContainerWidget;
@@ -51,7 +51,7 @@ final class ScenariosPanel
 
     public function showResult(ScenarioResult $result): void
     {
-        $this->resultLine->setText(TerminalSafeText::stripControlBytes($this->formatResult($result)));
+        $this->resultLine->setText(TerminalSafeText::stripControlBytes(ScenarioResultFormatter::format($result)));
     }
 
     public function clearResult(): void
@@ -62,29 +62,6 @@ final class ScenariosPanel
     public function currentResultText(): string
     {
         return $this->resultLine->getText();
-    }
-
-    private function formatResult(ScenarioResult $result): string
-    {
-        return match ($result->kind) {
-            ScenarioResultKind::Success => $this->formatSuccess($result),
-            ScenarioResultKind::ValidationFailure => 'VALIDATION '.$result->message,
-            ScenarioResultKind::TransportFailure => null !== $result->httpStatus
-                ? \sprintf('FAIL HTTP %d: %s', $result->httpStatus, $result->message)
-                : 'FAIL '.$result->message,
-            ScenarioResultKind::Unreachable => 'UNREACHABLE '.$result->message,
-        };
-    }
-
-    private function formatSuccess(ScenarioResult $result): string
-    {
-        $statusOnly = 'OK '.($result->httpStatus ?? 0);
-
-        if ('' === $result->message || 'OK' === $result->message) {
-            return $statusOnly;
-        }
-
-        return $statusOnly.': '.$result->message;
     }
 
     /**

--- a/src/Tui/Scenarios/ScenarioResultFormatter.php
+++ b/src/Tui/Scenarios/ScenarioResultFormatter.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Scenarios;
+
+final class ScenarioResultFormatter
+{
+    public static function format(ScenarioResult $result): string
+    {
+        return match ($result->kind) {
+            ScenarioResultKind::Success => self::formatSuccess($result),
+            ScenarioResultKind::ValidationFailure => 'VALIDATION '.$result->message,
+            ScenarioResultKind::TransportFailure => null !== $result->httpStatus
+                ? \sprintf('FAIL HTTP %d: %s', $result->httpStatus, $result->message)
+                : 'FAIL '.$result->message,
+            ScenarioResultKind::Unreachable => 'UNREACHABLE '.$result->message,
+        };
+    }
+
+    private static function formatSuccess(ScenarioResult $result): string
+    {
+        $statusOnly = 'OK '.($result->httpStatus ?? 0);
+
+        if ('' === $result->message || 'OK' === $result->message) {
+            return $statusOnly;
+        }
+
+        return $statusOnly.': '.$result->message;
+    }
+}

--- a/src/Tui/SyncNow/Panel/SyncNowPanel.php
+++ b/src/Tui/SyncNow/Panel/SyncNowPanel.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\SyncNow\Panel;
+
+use App\Tui\SyncNow\SyncNowResult;
+use App\Tui\SyncNow\SyncNowResultKind;
+use App\Tui\SyncNow\SyncTarget;
+use App\Tui\TerminalSafeText;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\SelectListWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+
+final class SyncNowPanel
+{
+    private const string HEADER_TEXT = 'Sync Now - [Enter] dispatch  [Esc] back';
+    private const string SEPARATOR_TEXT = '----------------------------------------------------------------';
+    private const string NEVER_DISPATCHED_LABEL = 'never';
+
+    private readonly TextWidget $resultLine;
+    private readonly SelectListWidget $list;
+    private readonly ContainerWidget $container;
+
+    /**
+     * @var array<string,string>
+     */
+    private array $lastDispatchByTargetId = [];
+
+    public function __construct()
+    {
+        $header = new TextWidget(self::HEADER_TEXT);
+        $separator = new TextWidget(self::SEPARATOR_TEXT);
+        $this->list = new SelectListWidget(
+            items: $this->buildSelectListItems(),
+            maxVisible: \count(SyncTarget::cases()),
+        );
+        $this->resultLine = new TextWidget('');
+
+        $this->container = new ContainerWidget();
+        $this->container->expandVertically(true);
+        $this->container->add($header);
+        $this->container->add($separator);
+        $this->container->add($this->list);
+        $this->container->add($this->resultLine);
+    }
+
+    public function widget(): ContainerWidget
+    {
+        return $this->container;
+    }
+
+    public function selectListWidget(): SelectListWidget
+    {
+        return $this->list;
+    }
+
+    public function recordDispatch(SyncTarget $target, \DateTimeImmutable $dispatchedAt): void
+    {
+        $this->lastDispatchByTargetId[$target->value] = $dispatchedAt->format('H:i:s');
+        $this->list->setItems($this->buildSelectListItems());
+    }
+
+    public function showResult(SyncNowResult $result): void
+    {
+        $this->resultLine->setText(TerminalSafeText::stripControlBytes($this->formatResult($result)));
+    }
+
+    public function clearResult(): void
+    {
+        $this->resultLine->setText('');
+    }
+
+    public function currentResultText(): string
+    {
+        return $this->resultLine->getText();
+    }
+
+    private function formatResult(SyncNowResult $result): string
+    {
+        return match ($result->kind) {
+            SyncNowResultKind::Dispatched => 'OK '.$result->message.' dispatched',
+            SyncNowResultKind::NotWired => 'NOT WIRED '.$result->message.' (class does not exist)',
+            SyncNowResultKind::DispatchError => 'FAIL: '.$result->message,
+        };
+    }
+
+    /**
+     * @return list<array{value: string, label: string}>
+     */
+    private function buildSelectListItems(): array
+    {
+        $items = [];
+        foreach (SyncTarget::cases() as $target) {
+            $lastDispatch = $this->lastDispatchByTargetId[$target->value] ?? self::NEVER_DISPATCHED_LABEL;
+            $items[] = [
+                'value' => $target->value,
+                'label' => \sprintf('%-22s last: %s', $target->label(), $lastDispatch),
+            ];
+        }
+
+        return $items;
+    }
+}

--- a/src/Tui/SyncNow/Panel/SyncNowPanel.php
+++ b/src/Tui/SyncNow/Panel/SyncNowPanel.php
@@ -17,6 +17,7 @@ final class SyncNowPanel
     private const string HEADER_TEXT = 'Sync Now - [Enter] dispatch  [Esc] back';
     private const string SEPARATOR_TEXT = '----------------------------------------------------------------';
     private const string NEVER_DISPATCHED_LABEL = 'never';
+    private const int LABEL_COLUMN_WIDTH = 22;
 
     private readonly TextWidget $resultLine;
     private readonly SelectListWidget $list;
@@ -58,7 +59,15 @@ final class SyncNowPanel
     public function recordDispatch(SyncTarget $target, \DateTimeImmutable $dispatchedAt): void
     {
         $this->lastDispatchByTargetId[$target->value] = $dispatchedAt->format('H:i:s');
+
+        $selectedTargetValue = $this->currentSelectedTargetValue();
         $this->list->setItems($this->buildSelectListItems());
+        $this->restoreSelectionFor($selectedTargetValue);
+    }
+
+    public function lastDispatchLabelFor(SyncTarget $target): string
+    {
+        return $this->lastDispatchByTargetId[$target->value] ?? self::NEVER_DISPATCHED_LABEL;
     }
 
     public function showResult(SyncNowResult $result): void
@@ -74,6 +83,28 @@ final class SyncNowPanel
     public function currentResultText(): string
     {
         return $this->resultLine->getText();
+    }
+
+    private function currentSelectedTargetValue(): ?string
+    {
+        $selected = $this->list->getSelectedItem();
+
+        return $selected['value'] ?? null;
+    }
+
+    private function restoreSelectionFor(?string $targetValue): void
+    {
+        if (null === $targetValue) {
+            return;
+        }
+
+        foreach (SyncTarget::cases() as $index => $target) {
+            if ($target->value === $targetValue) {
+                $this->list->setSelectedIndex($index);
+
+                return;
+            }
+        }
     }
 
     private function formatResult(SyncNowResult $result): string
@@ -92,10 +123,13 @@ final class SyncNowPanel
     {
         $items = [];
         foreach (SyncTarget::cases() as $target) {
-            $lastDispatch = $this->lastDispatchByTargetId[$target->value] ?? self::NEVER_DISPATCHED_LABEL;
             $items[] = [
                 'value' => $target->value,
-                'label' => \sprintf('%-22s last: %s', $target->label(), $lastDispatch),
+                'label' => \sprintf(
+                    '%-'.self::LABEL_COLUMN_WIDTH.'s last: %s',
+                    $target->label(),
+                    $this->lastDispatchLabelFor($target),
+                ),
             ];
         }
 

--- a/src/Tui/SyncNow/SyncNowDispatcher.php
+++ b/src/Tui/SyncNow/SyncNowDispatcher.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\SyncNow;
+
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final readonly class SyncNowDispatcher
+{
+    public function __construct(
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function dispatch(SyncTarget $target): SyncNowResult
+    {
+        return $this->dispatchClass($target->messageClass());
+    }
+
+    public function dispatchClass(string $messageClass): SyncNowResult
+    {
+        if (!class_exists($messageClass)) {
+            return SyncNowResult::notWired($messageClass);
+        }
+
+        try {
+            $message = new $messageClass();
+            $this->messageBus->dispatch($message);
+        } catch (\Throwable $error) {
+            return SyncNowResult::dispatchError($error->getMessage());
+        }
+
+        return SyncNowResult::dispatched($messageClass);
+    }
+}

--- a/src/Tui/SyncNow/SyncNowResult.php
+++ b/src/Tui/SyncNow/SyncNowResult.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\SyncNow;
+
+final readonly class SyncNowResult
+{
+    private function __construct(
+        public SyncNowResultKind $kind,
+        public string $message,
+    ) {
+    }
+
+    public static function dispatched(string $messageClass): self
+    {
+        return new self(SyncNowResultKind::Dispatched, $messageClass);
+    }
+
+    public static function notWired(string $messageClass): self
+    {
+        return new self(SyncNowResultKind::NotWired, $messageClass);
+    }
+
+    public static function dispatchError(string $errorMessage): self
+    {
+        return new self(SyncNowResultKind::DispatchError, $errorMessage);
+    }
+}

--- a/src/Tui/SyncNow/SyncNowResultKind.php
+++ b/src/Tui/SyncNow/SyncNowResultKind.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\SyncNow;
+
+enum SyncNowResultKind: string
+{
+    case Dispatched = 'dispatched';
+    case NotWired = 'not_wired';
+    case DispatchError = 'dispatch_error';
+}

--- a/src/Tui/SyncNow/SyncTarget.php
+++ b/src/Tui/SyncNow/SyncTarget.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\SyncNow;
+
+enum SyncTarget: string
+{
+    case Weather = 'sync-weather';
+    case Tracker = 'sync-tracker';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Weather => 'SyncWeatherMessage',
+            self::Tracker => 'SyncTrackerMessage',
+        };
+    }
+
+    public function messageClass(): string
+    {
+        return match ($this) {
+            self::Weather => 'App\\Message\\SyncWeatherMessage',
+            self::Tracker => 'App\\Message\\SyncTrackerMessage',
+        };
+    }
+}

--- a/tests/Command/TuiCommandWiringTest.php
+++ b/tests/Command/TuiCommandWiringTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace App\Tests\Command;
 
 use App\Command\TuiCommand;
+use App\Tui\ResetSim\ResetSimulatorAction;
 use App\Tui\Scenarios\ScenarioCatalog;
 use App\Tui\Scenarios\ScenarioDispatcher;
 use App\Tui\Scenarios\Transport\ScenarioHttpClient;
 use App\Tui\Scenarios\Validation\OutboundPayloadValidator;
+use App\Tui\SyncNow\SyncNowDispatcher;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class TuiCommandWiringTest extends KernelTestCase
@@ -56,5 +58,23 @@ final class TuiCommandWiringTest extends KernelTestCase
         $httpClient = self::getContainer()->get(ScenarioHttpClient::class);
 
         self::assertInstanceOf(ScenarioHttpClient::class, $httpClient);
+    }
+
+    public function testSyncNowDispatcherResolvesFromContainer(): void
+    {
+        self::bootKernel();
+
+        $syncNowDispatcher = self::getContainer()->get(SyncNowDispatcher::class);
+
+        self::assertInstanceOf(SyncNowDispatcher::class, $syncNowDispatcher);
+    }
+
+    public function testResetSimulatorActionResolvesFromContainer(): void
+    {
+        self::bootKernel();
+
+        $resetSimulatorAction = self::getContainer()->get(ResetSimulatorAction::class);
+
+        self::assertInstanceOf(ResetSimulatorAction::class, $resetSimulatorAction);
     }
 }

--- a/tests/Tui/ResetSim/Panel/ResetSimPanelTest.php
+++ b/tests/Tui/ResetSim/Panel/ResetSimPanelTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\ResetSim\Panel;
+
+use App\Tui\ResetSim\Panel\ResetSimPanel;
+use App\Tui\Scenarios\ScenarioResult;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\SelectListWidget;
+
+final class ResetSimPanelTest extends TestCase
+{
+    private ResetSimPanel $panel;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->panel = new ResetSimPanel();
+    }
+
+    public function testWidgetIsContainerAndInitialResultIsEmpty(): void
+    {
+        self::assertInstanceOf(ContainerWidget::class, $this->panel->widget());
+        self::assertInstanceOf(SelectListWidget::class, $this->panel->selectListWidget());
+        self::assertSame('', $this->panel->currentResultText());
+    }
+
+    public function testInitialPanelExposesSingleSelectableItem(): void
+    {
+        $selected = $this->panel->selectListWidget()->getSelectedItem();
+
+        self::assertNotNull($selected);
+        self::assertSame('reset', $selected['value']);
+        self::assertStringContainsString('POST /__reset', $selected['label']);
+    }
+
+    public function testShowResultFormatsSuccess(): void
+    {
+        $this->panel->showResult(ScenarioResult::success(200));
+
+        self::assertSame('OK 200', $this->panel->currentResultText());
+    }
+
+    public function testShowResultFormatsTransportFailureWithStatus(): void
+    {
+        $this->panel->showResult(ScenarioResult::transportFailure('server error', 500));
+
+        self::assertSame('FAIL HTTP 500: server error', $this->panel->currentResultText());
+    }
+
+    public function testShowResultFormatsTransportFailureWithoutStatus(): void
+    {
+        $this->panel->showResult(ScenarioResult::transportFailure('Transport error: boom'));
+
+        self::assertSame('FAIL Transport error: boom', $this->panel->currentResultText());
+    }
+
+    public function testShowResultFormatsUnreachable(): void
+    {
+        $this->panel->showResult(ScenarioResult::unreachable('connection refused'));
+
+        self::assertSame('UNREACHABLE connection refused', $this->panel->currentResultText());
+    }
+
+    public function testClearResultEmptiesTheResultLine(): void
+    {
+        $this->panel->showResult(ScenarioResult::success(200));
+
+        $this->panel->clearResult();
+
+        self::assertSame('', $this->panel->currentResultText());
+    }
+}

--- a/tests/Tui/ResetSim/ResetSimulatorActionTest.php
+++ b/tests/Tui/ResetSim/ResetSimulatorActionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\ResetSim;
+
+use App\Tests\Tui\Scenarios\Stub\CapturingScenarioTransportStub;
+use App\Tests\Tui\Scenarios\Stub\ThrowingScenarioTransportStub;
+use App\Tui\ResetSim\ResetSimulatorAction;
+use App\Tui\Scenarios\DeviceBaseUrl;
+use App\Tui\Scenarios\ScenarioResult;
+use App\Tui\Scenarios\ScenarioResultKind;
+use PHPUnit\Framework\TestCase;
+
+final class ResetSimulatorActionTest extends TestCase
+{
+    private const string TEST_DEVICE_BASE_URL = 'http://simulator:8080';
+
+    public function testResetSendsPostToResetEndpointWithoutBody(): void
+    {
+        $transport = new CapturingScenarioTransportStub(ScenarioResult::success(200));
+        $action = new ResetSimulatorAction($transport, self::TEST_DEVICE_BASE_URL);
+
+        $result = $action->reset();
+
+        self::assertSame(ScenarioResultKind::Success, $result->kind);
+        self::assertSame(200, $result->httpStatus);
+        self::assertCount(1, $transport->calls);
+        self::assertSame('POST', $transport->calls[0]['method']);
+        self::assertSame(self::TEST_DEVICE_BASE_URL.'/__reset', $transport->calls[0]['url']);
+        self::assertNull($transport->calls[0]['body']);
+    }
+
+    public function testResetReturnsTransportFailureWhenTransportThrows(): void
+    {
+        $throwingTransport = new ThrowingScenarioTransportStub(new \RuntimeException('boom'));
+        $action = new ResetSimulatorAction($throwingTransport, self::TEST_DEVICE_BASE_URL);
+
+        $result = $action->reset();
+
+        self::assertSame(ScenarioResultKind::TransportFailure, $result->kind);
+        self::assertNull($result->httpStatus);
+        self::assertStringContainsString('boom', $result->message);
+    }
+
+    public function testResetResolvesBaseUrlFromDefaultWhenConfigIsNull(): void
+    {
+        $transport = new CapturingScenarioTransportStub(ScenarioResult::success(200));
+        $action = new ResetSimulatorAction($transport, null);
+
+        $action->reset();
+
+        self::assertCount(1, $transport->calls);
+        self::assertStringStartsWith(DeviceBaseUrl::DEFAULT, $transport->calls[0]['url']);
+        self::assertStringEndsWith('/__reset', $transport->calls[0]['url']);
+    }
+}

--- a/tests/Tui/ResetSim/ResetSimulatorActionTest.php
+++ b/tests/Tui/ResetSim/ResetSimulatorActionTest.php
@@ -7,19 +7,39 @@ namespace App\Tests\Tui\ResetSim;
 use App\Tests\Tui\Scenarios\Stub\CapturingScenarioTransportStub;
 use App\Tests\Tui\Scenarios\Stub\ThrowingScenarioTransportStub;
 use App\Tui\ResetSim\ResetSimulatorAction;
-use App\Tui\Scenarios\DeviceBaseUrl;
+use App\Tui\Scenarios\ScenarioCatalog;
+use App\Tui\Scenarios\ScenarioDispatcher;
 use App\Tui\Scenarios\ScenarioResult;
 use App\Tui\Scenarios\ScenarioResultKind;
+use App\Tui\Scenarios\Validation\OutboundOpenApiValidatorFactory;
+use App\Tui\Scenarios\Validation\OutboundPayloadValidator;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 
 final class ResetSimulatorActionTest extends TestCase
 {
     private const string TEST_DEVICE_BASE_URL = 'http://simulator:8080';
 
-    public function testResetSendsPostToResetEndpointWithoutBody(): void
+    private OutboundPayloadValidator $validator;
+
+    protected function setUp(): void
     {
-        $transport = new CapturingScenarioTransportStub(ScenarioResult::success(200));
-        $action = new ResetSimulatorAction($transport, self::TEST_DEVICE_BASE_URL);
+        parent::setUp();
+
+        $projectDir = \dirname(__DIR__, 3);
+        $factory = new OutboundOpenApiValidatorFactory($projectDir, self::TEST_DEVICE_BASE_URL);
+        $this->validator = new OutboundPayloadValidator(
+            $factory->create(),
+            new Psr17Factory(),
+            self::TEST_DEVICE_BASE_URL,
+        );
+    }
+
+    public function testResetDispatchesResetSimulatorScenarioAndReturnsTransportResult(): void
+    {
+        $transport = new CapturingScenarioTransportStub(ScenarioResult::success(200, 'OK 200'));
+        $dispatcher = new ScenarioDispatcher($this->validator, $transport, self::TEST_DEVICE_BASE_URL);
+        $action = new ResetSimulatorAction(new ScenarioCatalog(), $dispatcher);
 
         $result = $action->reset();
 
@@ -27,31 +47,20 @@ final class ResetSimulatorActionTest extends TestCase
         self::assertSame(200, $result->httpStatus);
         self::assertCount(1, $transport->calls);
         self::assertSame('POST', $transport->calls[0]['method']);
-        self::assertSame(self::TEST_DEVICE_BASE_URL.'/__reset', $transport->calls[0]['url']);
+        self::assertStringEndsWith('/__reset', $transport->calls[0]['url']);
         self::assertNull($transport->calls[0]['body']);
     }
 
-    public function testResetReturnsTransportFailureWhenTransportThrows(): void
+    public function testResetReturnsTransportFailureWhenDispatcherTransportThrows(): void
     {
         $throwingTransport = new ThrowingScenarioTransportStub(new \RuntimeException('boom'));
-        $action = new ResetSimulatorAction($throwingTransport, self::TEST_DEVICE_BASE_URL);
+        $dispatcher = new ScenarioDispatcher($this->validator, $throwingTransport, self::TEST_DEVICE_BASE_URL);
+        $action = new ResetSimulatorAction(new ScenarioCatalog(), $dispatcher);
 
         $result = $action->reset();
 
         self::assertSame(ScenarioResultKind::TransportFailure, $result->kind);
         self::assertNull($result->httpStatus);
         self::assertStringContainsString('boom', $result->message);
-    }
-
-    public function testResetResolvesBaseUrlFromDefaultWhenConfigIsNull(): void
-    {
-        $transport = new CapturingScenarioTransportStub(ScenarioResult::success(200));
-        $action = new ResetSimulatorAction($transport, null);
-
-        $action->reset();
-
-        self::assertCount(1, $transport->calls);
-        self::assertStringStartsWith(DeviceBaseUrl::DEFAULT, $transport->calls[0]['url']);
-        self::assertStringEndsWith('/__reset', $transport->calls[0]['url']);
     }
 }

--- a/tests/Tui/Scenarios/ScenarioDispatcherTest.php
+++ b/tests/Tui/Scenarios/ScenarioDispatcherTest.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace App\Tests\Tui\Scenarios;
 
+use App\Tests\Tui\Scenarios\Stub\CapturingScenarioTransportStub;
+use App\Tests\Tui\Scenarios\Stub\ThrowingScenarioTransportStub;
 use App\Tui\Scenarios\ScenarioCatalog;
 use App\Tui\Scenarios\ScenarioDefinition;
 use App\Tui\Scenarios\ScenarioDispatcher;
 use App\Tui\Scenarios\ScenarioResult;
-use App\Tui\Scenarios\Transport\ScenarioTransport;
 use App\Tui\Scenarios\Validation\OutboundOpenApiValidatorFactory;
 use App\Tui\Scenarios\Validation\OutboundPayloadValidator;
 use App\Tui\TuiMode;
@@ -122,42 +123,5 @@ final class ScenarioDispatcherTest extends TestCase
         self::assertFalse($result->success);
         self::assertNull($result->httpStatus);
         self::assertStringContainsString('boom', $result->message);
-    }
-}
-
-final class CapturingScenarioTransportStub implements ScenarioTransport
-{
-    /**
-     * @var list<array{method: string, url: string, body: array<string,mixed>|null}>
-     */
-    public array $calls = [];
-
-    public function __construct(
-        private readonly ScenarioResult $resultToReturn,
-    ) {
-    }
-
-    public function send(string $method, string $url, ?array $body): ScenarioResult
-    {
-        $this->calls[] = [
-            'method' => $method,
-            'url' => $url,
-            'body' => $body,
-        ];
-
-        return $this->resultToReturn;
-    }
-}
-
-final class ThrowingScenarioTransportStub implements ScenarioTransport
-{
-    public function __construct(
-        private readonly \Throwable $exceptionToThrow,
-    ) {
-    }
-
-    public function send(string $method, string $url, ?array $body): ScenarioResult
-    {
-        throw $this->exceptionToThrow;
     }
 }

--- a/tests/Tui/Scenarios/Stub/CapturingScenarioTransportStub.php
+++ b/tests/Tui/Scenarios/Stub/CapturingScenarioTransportStub.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Scenarios\Stub;
+
+use App\Tui\Scenarios\ScenarioResult;
+use App\Tui\Scenarios\Transport\ScenarioTransport;
+
+final class CapturingScenarioTransportStub implements ScenarioTransport
+{
+    /**
+     * @var list<array{method: string, url: string, body: array<string,mixed>|null}>
+     */
+    public array $calls = [];
+
+    public function __construct(
+        private readonly ScenarioResult $resultToReturn,
+    ) {
+    }
+
+    public function send(string $method, string $url, ?array $body): ScenarioResult
+    {
+        $this->calls[] = [
+            'method' => $method,
+            'url' => $url,
+            'body' => $body,
+        ];
+
+        return $this->resultToReturn;
+    }
+}

--- a/tests/Tui/Scenarios/Stub/ThrowingScenarioTransportStub.php
+++ b/tests/Tui/Scenarios/Stub/ThrowingScenarioTransportStub.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Scenarios\Stub;
+
+use App\Tui\Scenarios\ScenarioResult;
+use App\Tui\Scenarios\Transport\ScenarioTransport;
+
+final class ThrowingScenarioTransportStub implements ScenarioTransport
+{
+    public function __construct(
+        private readonly \Throwable $exceptionToThrow,
+    ) {
+    }
+
+    public function send(string $method, string $url, ?array $body): ScenarioResult
+    {
+        throw $this->exceptionToThrow;
+    }
+}

--- a/tests/Tui/SyncNow/Panel/SyncNowPanelTest.php
+++ b/tests/Tui/SyncNow/Panel/SyncNowPanelTest.php
@@ -29,7 +29,7 @@ final class SyncNowPanelTest extends TestCase
         self::assertSame('', $this->panel->currentResultText());
     }
 
-    public function testInitialListShowsTargetLabelsWithLastNever(): void
+    public function testInitialListShowsFirstTargetLabelWithLastNever(): void
     {
         $selected = $this->panel->selectListWidget()->getSelectedItem();
 
@@ -39,20 +39,35 @@ final class SyncNowPanelTest extends TestCase
         self::assertStringContainsString('last: never', $selected['label']);
     }
 
-    public function testRecordDispatchUpdatesLabelWithFormattedTimestamp(): void
+    public function testInitialLastDispatchLabelForEveryTargetIsNever(): void
+    {
+        foreach (SyncTarget::cases() as $target) {
+            self::assertSame('never', $this->panel->lastDispatchLabelFor($target));
+        }
+    }
+
+    public function testRecordDispatchStoresFormattedTimestampForTargetOnly(): void
     {
         $dispatchedAt = new \DateTimeImmutable('2026-05-25 14:32:07');
 
         $this->panel->recordDispatch(SyncTarget::Weather, $dispatchedAt);
 
-        $items = $this->extractAllItems($this->panel->selectListWidget());
-        $weatherItem = $this->findItemByValue($items, 'sync-weather');
-        $trackerItem = $this->findItemByValue($items, 'sync-tracker');
+        self::assertSame('14:32:07', $this->panel->lastDispatchLabelFor(SyncTarget::Weather));
+        self::assertSame('never', $this->panel->lastDispatchLabelFor(SyncTarget::Tracker));
+    }
 
-        self::assertNotNull($weatherItem);
-        self::assertStringContainsString('last: 14:32:07', $weatherItem['label']);
-        self::assertNotNull($trackerItem);
-        self::assertStringContainsString('last: never', $trackerItem['label']);
+    public function testRecordDispatchPreservesSelectedTarget(): void
+    {
+        $this->panel->selectListWidget()->setSelectedIndex(1);
+        $trackerBeforeDispatch = $this->panel->selectListWidget()->getSelectedItem();
+        self::assertNotNull($trackerBeforeDispatch);
+        self::assertSame('sync-tracker', $trackerBeforeDispatch['value']);
+
+        $this->panel->recordDispatch(SyncTarget::Tracker, new \DateTimeImmutable('2026-05-25 14:32:07'));
+
+        $selectedAfterDispatch = $this->panel->selectListWidget()->getSelectedItem();
+        self::assertNotNull($selectedAfterDispatch);
+        self::assertSame('sync-tracker', $selectedAfterDispatch['value']);
     }
 
     public function testShowResultFormatsDispatched(): void
@@ -93,34 +108,5 @@ final class SyncNowPanelTest extends TestCase
         $this->panel->clearResult();
 
         self::assertSame('', $this->panel->currentResultText());
-    }
-
-    /**
-     * @return list<array{value: string, label: string, description?: string}>
-     */
-    private function extractAllItems(SelectListWidget $widget): array
-    {
-        $reflection = new \ReflectionProperty($widget, 'filteredItems');
-
-        /** @var list<array{value: string, label: string, description?: string}> $items */
-        $items = $reflection->getValue($widget);
-
-        return $items;
-    }
-
-    /**
-     * @param list<array{value: string, label: string, description?: string}> $items
-     *
-     * @return array{value: string, label: string, description?: string}|null
-     */
-    private function findItemByValue(array $items, string $value): ?array
-    {
-        foreach ($items as $item) {
-            if ($item['value'] === $value) {
-                return $item;
-            }
-        }
-
-        return null;
     }
 }

--- a/tests/Tui/SyncNow/Panel/SyncNowPanelTest.php
+++ b/tests/Tui/SyncNow/Panel/SyncNowPanelTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\SyncNow\Panel;
+
+use App\Tui\SyncNow\Panel\SyncNowPanel;
+use App\Tui\SyncNow\SyncNowResult;
+use App\Tui\SyncNow\SyncTarget;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\SelectListWidget;
+
+final class SyncNowPanelTest extends TestCase
+{
+    private SyncNowPanel $panel;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->panel = new SyncNowPanel();
+    }
+
+    public function testWidgetIsContainerAndInitialResultIsEmpty(): void
+    {
+        self::assertInstanceOf(ContainerWidget::class, $this->panel->widget());
+        self::assertInstanceOf(SelectListWidget::class, $this->panel->selectListWidget());
+        self::assertSame('', $this->panel->currentResultText());
+    }
+
+    public function testInitialListShowsTargetLabelsWithLastNever(): void
+    {
+        $selected = $this->panel->selectListWidget()->getSelectedItem();
+
+        self::assertNotNull($selected);
+        self::assertSame('sync-weather', $selected['value']);
+        self::assertStringContainsString('SyncWeatherMessage', $selected['label']);
+        self::assertStringContainsString('last: never', $selected['label']);
+    }
+
+    public function testRecordDispatchUpdatesLabelWithFormattedTimestamp(): void
+    {
+        $dispatchedAt = new \DateTimeImmutable('2026-05-25 14:32:07');
+
+        $this->panel->recordDispatch(SyncTarget::Weather, $dispatchedAt);
+
+        $items = $this->extractAllItems($this->panel->selectListWidget());
+        $weatherItem = $this->findItemByValue($items, 'sync-weather');
+        $trackerItem = $this->findItemByValue($items, 'sync-tracker');
+
+        self::assertNotNull($weatherItem);
+        self::assertStringContainsString('last: 14:32:07', $weatherItem['label']);
+        self::assertNotNull($trackerItem);
+        self::assertStringContainsString('last: never', $trackerItem['label']);
+    }
+
+    public function testShowResultFormatsDispatched(): void
+    {
+        $this->panel->showResult(SyncNowResult::dispatched('App\\Message\\SyncWeatherMessage'));
+
+        self::assertSame('OK App\\Message\\SyncWeatherMessage dispatched', $this->panel->currentResultText());
+    }
+
+    public function testShowResultFormatsNotWired(): void
+    {
+        $this->panel->showResult(SyncNowResult::notWired('App\\Message\\SyncWeatherMessage'));
+
+        self::assertSame(
+            'NOT WIRED App\\Message\\SyncWeatherMessage (class does not exist)',
+            $this->panel->currentResultText(),
+        );
+    }
+
+    public function testShowResultFormatsDispatchError(): void
+    {
+        $this->panel->showResult(SyncNowResult::dispatchError('bus down'));
+
+        self::assertSame('FAIL: bus down', $this->panel->currentResultText());
+    }
+
+    public function testShowResultStripsControlBytes(): void
+    {
+        $this->panel->showResult(SyncNowResult::dispatchError("bus\x1b[2J down"));
+
+        self::assertSame('FAIL: bus[2J down', $this->panel->currentResultText());
+    }
+
+    public function testClearResultEmptiesTheResultLine(): void
+    {
+        $this->panel->showResult(SyncNowResult::dispatched('App\\Message\\SyncWeatherMessage'));
+
+        $this->panel->clearResult();
+
+        self::assertSame('', $this->panel->currentResultText());
+    }
+
+    /**
+     * @return list<array{value: string, label: string, description?: string}>
+     */
+    private function extractAllItems(SelectListWidget $widget): array
+    {
+        $reflection = new \ReflectionProperty($widget, 'filteredItems');
+
+        /** @var list<array{value: string, label: string, description?: string}> $items */
+        $items = $reflection->getValue($widget);
+
+        return $items;
+    }
+
+    /**
+     * @param list<array{value: string, label: string, description?: string}> $items
+     *
+     * @return array{value: string, label: string, description?: string}|null
+     */
+    private function findItemByValue(array $items, string $value): ?array
+    {
+        foreach ($items as $item) {
+            if ($item['value'] === $value) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Tui/SyncNow/Stub/CapturingMessageBusStub.php
+++ b/tests/Tui/SyncNow/Stub/CapturingMessageBusStub.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\SyncNow\Stub;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class CapturingMessageBusStub implements MessageBusInterface
+{
+    /**
+     * @var list<object>
+     */
+    public array $dispatched = [];
+
+    public function dispatch(object $message, array $stamps = []): Envelope
+    {
+        $this->dispatched[] = $message;
+
+        return new Envelope($message);
+    }
+}

--- a/tests/Tui/SyncNow/Stub/ThrowingMessageBusStub.php
+++ b/tests/Tui/SyncNow/Stub/ThrowingMessageBusStub.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\SyncNow\Stub;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class ThrowingMessageBusStub implements MessageBusInterface
+{
+    public function __construct(
+        private readonly \Throwable $exceptionToThrow,
+    ) {
+    }
+
+    public function dispatch(object $message, array $stamps = []): Envelope
+    {
+        throw $this->exceptionToThrow;
+    }
+}

--- a/tests/Tui/SyncNow/SyncNowDispatcherTest.php
+++ b/tests/Tui/SyncNow/SyncNowDispatcherTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\SyncNow;
+
+use App\Tui\SyncNow\SyncNowDispatcher;
+use App\Tui\SyncNow\SyncNowResultKind;
+use App\Tui\SyncNow\SyncTarget;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class SyncNowDispatcherTest extends TestCase
+{
+    public function testNotWiredWhenMessageClassDoesNotExist(): void
+    {
+        $bus = new CapturingMessageBusStub();
+        $dispatcher = new SyncNowDispatcher($bus);
+
+        $result = $dispatcher->dispatch(SyncTarget::Weather);
+
+        self::assertSame(SyncNowResultKind::NotWired, $result->kind);
+        self::assertSame('App\\Message\\SyncWeatherMessage', $result->message);
+        self::assertSame([], $bus->dispatched);
+    }
+
+    public function testDispatchedWhenMessageClassExists(): void
+    {
+        $bus = new CapturingMessageBusStub();
+        $dispatcher = new SyncNowDispatcher($bus);
+
+        $result = $dispatcher->dispatchClass(DummySyncMessage::class);
+
+        self::assertSame(SyncNowResultKind::Dispatched, $result->kind);
+        self::assertSame(DummySyncMessage::class, $result->message);
+        self::assertCount(1, $bus->dispatched);
+        self::assertInstanceOf(DummySyncMessage::class, $bus->dispatched[0]);
+    }
+
+    public function testDispatchErrorWhenBusThrows(): void
+    {
+        $bus = new ThrowingMessageBusStub(new \RuntimeException('bus down'));
+        $dispatcher = new SyncNowDispatcher($bus);
+
+        $result = $dispatcher->dispatchClass(DummySyncMessage::class);
+
+        self::assertSame(SyncNowResultKind::DispatchError, $result->kind);
+        self::assertStringContainsString('bus down', $result->message);
+    }
+}
+
+final class DummySyncMessage
+{
+}
+
+final class CapturingMessageBusStub implements MessageBusInterface
+{
+    /**
+     * @var list<object>
+     */
+    public array $dispatched = [];
+
+    public function dispatch(object $message, array $stamps = []): Envelope
+    {
+        $this->dispatched[] = $message;
+
+        return new Envelope($message);
+    }
+}
+
+final class ThrowingMessageBusStub implements MessageBusInterface
+{
+    public function __construct(
+        private readonly \Throwable $exceptionToThrow,
+    ) {
+    }
+
+    public function dispatch(object $message, array $stamps = []): Envelope
+    {
+        throw $this->exceptionToThrow;
+    }
+}

--- a/tests/Tui/SyncNow/SyncNowDispatcherTest.php
+++ b/tests/Tui/SyncNow/SyncNowDispatcherTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace App\Tests\Tui\SyncNow;
 
+use App\Tests\Tui\SyncNow\Stub\CapturingMessageBusStub;
+use App\Tests\Tui\SyncNow\Stub\ThrowingMessageBusStub;
 use App\Tui\SyncNow\SyncNowDispatcher;
 use App\Tui\SyncNow\SyncNowResultKind;
 use App\Tui\SyncNow\SyncTarget;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\MessageBusInterface;
 
 final class SyncNowDispatcherTest extends TestCase
 {
@@ -52,32 +52,4 @@ final class SyncNowDispatcherTest extends TestCase
 
 final class DummySyncMessage
 {
-}
-
-final class CapturingMessageBusStub implements MessageBusInterface
-{
-    /**
-     * @var list<object>
-     */
-    public array $dispatched = [];
-
-    public function dispatch(object $message, array $stamps = []): Envelope
-    {
-        $this->dispatched[] = $message;
-
-        return new Envelope($message);
-    }
-}
-
-final class ThrowingMessageBusStub implements MessageBusInterface
-{
-    public function __construct(
-        private readonly \Throwable $exceptionToThrow,
-    ) {
-    }
-
-    public function dispatch(object $message, array $stamps = []): Envelope
-    {
-        throw $this->exceptionToThrow;
-    }
 }


### PR DESCRIPTION
## Summary

Adds two dev-only TUI menu items: `[2] Sync Now` dispatches `SyncWeatherMessage` / `SyncTrackerMessage` directly on the Symfony message bus (with graceful "Not yet wired" fallback when the message classes do not yet exist) and tracks a per-target last-dispatch timestamp; `[4] Reset Sim` triggers the existing `reset-simulator` scenario (POST `/__reset`) via `ScenarioDispatcher` and shows the result inline.

`src/Schedule.php` is not modified.

Closes #31