### PR TITLE
feat(config): add pixelcast.yaml editor with TUI Configuration panel (#32)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 ###< phpunit/phpunit ###
 
 /phpstan-baseline.neon
+
+###> pixelcast config ###
+/pixelcast.yaml
+###< pixelcast config ###

--- a/pixelcast.yaml.dist
+++ b/pixelcast.yaml.dist
@@ -1,0 +1,17 @@
+# Base URL of the PixelCast device API (no trailing slash).
+device_url: http://pixelcast.local/api
+
+# Polling interval for the weather syncer (seconds).
+weather_interval: 300
+
+# Polling interval for the tracker syncer (seconds).
+tracker_interval: 60
+
+# Comma-separated list of tracked asset symbols.
+tracked_assets: BTC, AAPL, SPY, ETH
+
+# Identifier of the weather data provider.
+weather_source: openmeteo
+
+# Identifier of the tracker data provider.
+tracker_source: yahoo-finance

--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace App\Command;
 
+use App\Config\PixelCastConfigLoader;
+use App\Config\PixelCastConfigWriter;
+use App\Tui\Configuration\ConfigurationFieldValidator;
+use App\Tui\Configuration\Panel\ConfigurationPanel;
+use App\Tui\Configuration\SaveOutcome;
 use App\Tui\Inspector\InspectorPoller;
 use App\Tui\Inspector\InspectorTransport;
 use App\Tui\Inspector\RequestLogPanel;
@@ -16,6 +21,7 @@ use App\Tui\ResetSim\ResetSimulatorAction;
 use App\Tui\Scenarios\Panel\ScenariosPanel;
 use App\Tui\Scenarios\ScenarioCatalog;
 use App\Tui\Scenarios\ScenarioDispatcher;
+use App\Tui\StatusBar\StatusBarWidget;
 use App\Tui\SyncNow\Panel\SyncNowPanel;
 use App\Tui\SyncNow\SyncNowDispatcher;
 use App\Tui\SyncNow\SyncNowResultKind;
@@ -35,7 +41,6 @@ use Symfony\Component\Tui\Tui;
 use Symfony\Component\Tui\Widget\AbstractWidget;
 use Symfony\Component\Tui\Widget\ContainerWidget;
 use Symfony\Component\Tui\Widget\SelectListWidget;
-use Symfony\Component\Tui\Widget\TextWidget;
 
 #[AsCommand(name: 'app:tui', description: 'Opens the PixelCast unified terminal interface')]
 final class TuiCommand extends Command
@@ -53,6 +58,9 @@ final class TuiCommand extends Command
         private readonly ScenarioDispatcher $scenarioDispatcher,
         private readonly SyncNowDispatcher $syncNowDispatcher,
         private readonly ResetSimulatorAction $resetSimulatorAction,
+        private readonly PixelCastConfigLoader $pixelCastConfigLoader,
+        private readonly PixelCastConfigWriter $pixelCastConfigWriter,
+        private readonly ConfigurationFieldValidator $configurationFieldValidator,
     ) {
         parent::__construct();
     }
@@ -96,12 +104,28 @@ final class TuiCommand extends Command
             $resetSimPanel = new ResetSimPanel();
         }
 
+        $configurationPanel = null;
+        if (TuiMode::Prod === $mode) {
+            $configurationPanel = new ConfigurationPanel(
+                $this->pixelCastConfigLoader,
+                $this->pixelCastConfigWriter,
+                $this->configurationFieldValidator,
+            );
+        }
+
         $viewContainer = new ContainerWidget();
         $viewContainer->expandVertically(true);
         $viewContainer->add($mainBodyContainer);
 
+        $statusBar = new StatusBarWidget();
+        $statusBar->setBaseLine($this->buildStatusBarBaseLine(
+            $mode,
+            $reachabilityResult,
+            $configurationPanel?->currentDeviceUrl(),
+        ));
+
         $tui->add($viewContainer);
-        $tui->add($this->buildStatusBarWidget($mode, $reachabilityResult));
+        $tui->add($statusBar->widget());
 
         $viewWidgets = [
             TuiView::Main->value => $mainBodyContainer,
@@ -112,6 +136,14 @@ final class TuiCommand extends Command
         }
         if (null !== $resetSimPanel) {
             $viewWidgets[TuiView::ResetSim->value] = $resetSimPanel->widget();
+        }
+        if (null !== $configurationPanel) {
+            $viewWidgets[TuiView::Configuration->value] = $configurationPanel->widget();
+            $statusBar->setUnsavedChanges($configurationPanel->hasUnsavedChanges());
+            $configurationPanel->onUnsavedChangesChanged(static function (bool $hasUnsaved) use ($tui, $statusBar): void {
+                $statusBar->setUnsavedChanges($hasUnsaved);
+                $tui->requestRender();
+            });
         }
 
         if (null !== $inspectorPoller) {
@@ -210,13 +242,41 @@ final class TuiCommand extends Command
             });
         }
 
-        // Registered on the Tui (not on a widget) so Q quits before focus
-        // routing, regardless of which sub-panel currently has focus.
-        $tui->addListener(static function (InputEvent $event) use ($tui): void {
+        if (null !== $configurationPanel) {
+            $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $viewWidgets, $configurationPanel): void {
+                if ($event->getTarget() !== $configurationPanel->selectListWidget()) {
+                    return;
+                }
+
+                $configurationPanel->discardChanges();
+                $this->switchView($tui, $viewContainer, TuiView::Main, $viewWidgets);
+            });
+        }
+
+        $tui->addListener(function (InputEvent $event) use ($tui, $statusBar, $configurationPanel, $mode, $reachabilityResult): void {
             $rawInput = $event->getData();
             if ('q' === $rawInput || 'Q' === $rawInput) {
                 $event->stopPropagation();
                 $tui->stop();
+
+                return;
+            }
+
+            if (null !== $configurationPanel
+                && TuiView::Configuration === $this->currentView
+                && !$configurationPanel->isEditingField()
+                && ('s' === $rawInput || 'S' === $rawInput)
+            ) {
+                $event->stopPropagation();
+                $outcome = $configurationPanel->commitSave();
+                if (SaveOutcome::Saved === $outcome) {
+                    $statusBar->setBaseLine($this->buildStatusBarBaseLine(
+                        $mode,
+                        $reachabilityResult,
+                        $configurationPanel->currentDeviceUrl(),
+                    ));
+                }
+                $tui->requestRender();
             }
         });
 
@@ -290,18 +350,23 @@ final class TuiCommand extends Command
         return $mainPanel;
     }
 
-    private function buildStatusBarWidget(TuiMode $mode, DeviceReachabilityResult $reachabilityResult): AbstractWidget
-    {
-        $targetLabel = $this->formatTargetLabel($this->deviceBaseUrl);
+    private function buildStatusBarBaseLine(
+        TuiMode $mode,
+        DeviceReachabilityResult $reachabilityResult,
+        ?string $configurationDeviceUrl,
+    ): string {
+        $effectiveDeviceUrl = null !== $configurationDeviceUrl && '' !== $configurationDeviceUrl
+            ? $configurationDeviceUrl
+            : $this->deviceBaseUrl;
 
-        $statusLine = \sprintf(
+        $targetLabel = $this->formatTargetLabel($effectiveDeviceUrl);
+
+        return \sprintf(
             'MODE: %s   TARGET: %s (%s)   [Q] quit',
             $mode->displayLabel(),
             $targetLabel,
             $reachabilityResult->displayLabel,
         );
-
-        return new TextWidget($statusLine);
     }
 
     private function formatTargetLabel(?string $baseUrl): string

--- a/src/Command/TuiView.php
+++ b/src/Command/TuiView.php
@@ -10,4 +10,5 @@ enum TuiView: string
     case Scenarios = 'scenarios';
     case SyncNow = 'sync-now';
     case ResetSim = 'reset-sim';
+    case Configuration = 'configuration';
 }

--- a/src/Config/Exception/PixelCastConfigException.php
+++ b/src/Config/Exception/PixelCastConfigException.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Config\Exception;
+
+final class PixelCastConfigException extends \RuntimeException
+{
+    public static function fileNotFound(string $filePath): self
+    {
+        return new self(\sprintf('PixelCast config file not found at "%s".', $filePath));
+    }
+
+    public static function invalidYaml(string $filePath, \Throwable $previous): self
+    {
+        return new self(
+            \sprintf('Failed to parse PixelCast config at "%s": %s', $filePath, $previous->getMessage()),
+            0,
+            $previous,
+        );
+    }
+
+    public static function missingKey(string $key): self
+    {
+        return new self(\sprintf('Missing required PixelCast config key "%s".', $key));
+    }
+
+    public static function invalidValue(string $key, string $reason): self
+    {
+        return new self(\sprintf('Invalid value for PixelCast config key "%s": %s', $key, $reason));
+    }
+
+    public static function writeFailed(string $filePath, \Throwable $previous): self
+    {
+        return new self(
+            \sprintf('Failed to write PixelCast config to "%s": %s', $filePath, $previous->getMessage()),
+            0,
+            $previous,
+        );
+    }
+}

--- a/src/Config/PixelCastConfig.php
+++ b/src/Config/PixelCastConfig.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Config;
+
+use App\Config\Exception\PixelCastConfigException;
+
+final readonly class PixelCastConfig
+{
+    private const string KEY_DEVICE_URL = 'device_url';
+    private const string KEY_WEATHER_INTERVAL = 'weather_interval';
+    private const string KEY_TRACKER_INTERVAL = 'tracker_interval';
+    private const string KEY_TRACKED_ASSETS = 'tracked_assets';
+    private const string KEY_WEATHER_SOURCE = 'weather_source';
+    private const string KEY_TRACKER_SOURCE = 'tracker_source';
+
+    /**
+     * @param list<string> $trackedAssets
+     */
+    public function __construct(
+        public string $deviceUrl,
+        public int $weatherInterval,
+        public int $trackerInterval,
+        public array $trackedAssets,
+        public string $weatherSource,
+        public string $trackerSource,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function asStringKeyedMap(mixed $parsed, string $contextLabel): array
+    {
+        if (!\is_array($parsed)) {
+            throw PixelCastConfigException::invalidYaml($contextLabel, new \RuntimeException('top-level YAML must be a key-value map'));
+        }
+
+        $stringKeyed = [];
+        foreach ($parsed as $key => $value) {
+            if (!\is_string($key)) {
+                throw PixelCastConfigException::invalidYaml($contextLabel, new \RuntimeException('top-level YAML keys must be strings'));
+            }
+            $stringKeyed[$key] = $value;
+        }
+
+        return $stringKeyed;
+    }
+
+    /**
+     * @param array<string, mixed> $raw
+     */
+    public static function fromArray(array $raw): self
+    {
+        $deviceUrl = self::requireString($raw, self::KEY_DEVICE_URL);
+        $weatherInterval = self::requirePositiveInt($raw, self::KEY_WEATHER_INTERVAL);
+        $trackerInterval = self::requirePositiveInt($raw, self::KEY_TRACKER_INTERVAL);
+        $trackedAssetsRaw = self::requireString($raw, self::KEY_TRACKED_ASSETS);
+        $weatherSource = self::requireString($raw, self::KEY_WEATHER_SOURCE);
+        $trackerSource = self::requireString($raw, self::KEY_TRACKER_SOURCE);
+
+        return new self(
+            $deviceUrl,
+            $weatherInterval,
+            $trackerInterval,
+            self::splitTrackedAssets($trackedAssetsRaw),
+            $weatherSource,
+            $trackerSource,
+        );
+    }
+
+    /**
+     * @return array<string, scalar>
+     */
+    public function toRawMap(): array
+    {
+        return [
+            self::KEY_DEVICE_URL => $this->deviceUrl,
+            self::KEY_WEATHER_INTERVAL => $this->weatherInterval,
+            self::KEY_TRACKER_INTERVAL => $this->trackerInterval,
+            self::KEY_TRACKED_ASSETS => implode(', ', $this->trackedAssets),
+            self::KEY_WEATHER_SOURCE => $this->weatherSource,
+            self::KEY_TRACKER_SOURCE => $this->trackerSource,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $raw
+     */
+    private static function requireString(array $raw, string $key): string
+    {
+        if (!\array_key_exists($key, $raw)) {
+            throw PixelCastConfigException::missingKey($key);
+        }
+
+        $value = $raw[$key];
+        if (!\is_string($value)) {
+            throw PixelCastConfigException::invalidValue($key, 'expected string');
+        }
+
+        $trimmed = trim($value);
+        if ('' === $trimmed) {
+            throw PixelCastConfigException::invalidValue($key, 'must not be empty');
+        }
+
+        return $trimmed;
+    }
+
+    /**
+     * @param array<string, mixed> $raw
+     */
+    private static function requirePositiveInt(array $raw, string $key): int
+    {
+        if (!\array_key_exists($key, $raw)) {
+            throw PixelCastConfigException::missingKey($key);
+        }
+
+        $value = $raw[$key];
+        if (!\is_int($value) || $value <= 0) {
+            throw PixelCastConfigException::invalidValue($key, 'expected positive integer');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function splitTrackedAssets(string $raw): array
+    {
+        $tokens = explode(',', $raw);
+        $cleaned = [];
+        foreach ($tokens as $token) {
+            $trimmed = trim($token);
+            if ('' !== $trimmed) {
+                $cleaned[] = $trimmed;
+            }
+        }
+
+        return $cleaned;
+    }
+}

--- a/src/Config/PixelCastConfigLoader.php
+++ b/src/Config/PixelCastConfigLoader.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Config;
+
+use App\Config\Exception\PixelCastConfigException;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+final readonly class PixelCastConfigLoader
+{
+    public function __construct(
+        #[Autowire('%kernel.project_dir%/pixelcast.yaml')]
+        private string $configFilePath,
+    ) {
+    }
+
+    public function load(): PixelCastConfig
+    {
+        if (!$this->exists()) {
+            throw PixelCastConfigException::fileNotFound($this->configFilePath);
+        }
+
+        try {
+            $parsed = Yaml::parseFile($this->configFilePath);
+        } catch (ParseException $parseError) {
+            throw PixelCastConfigException::invalidYaml($this->configFilePath, $parseError);
+        }
+
+        return PixelCastConfig::fromArray(
+            PixelCastConfig::asStringKeyedMap($parsed, $this->configFilePath),
+        );
+    }
+
+    public function exists(): bool
+    {
+        return is_file($this->configFilePath);
+    }
+
+    public function filePath(): string
+    {
+        return $this->configFilePath;
+    }
+}

--- a/src/Config/PixelCastConfigWriter.php
+++ b/src/Config/PixelCastConfigWriter.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Config;
+
+use App\Config\Exception\PixelCastConfigException;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+final class PixelCastConfigWriter
+{
+    private const string TOP_LEVEL_KEY_LINE_PATTERN = '/^(?<indent>\s*)(?<key>[A-Za-z0-9_]+)\s*:\s*(?<value>.*?)\s*$/';
+
+    public function __construct(
+        #[Autowire('%kernel.project_dir%/pixelcast.yaml')]
+        private readonly string $configFilePath,
+        private readonly Filesystem $filesystem = new Filesystem(),
+    ) {
+    }
+
+    public function save(PixelCastConfig $config): void
+    {
+        $desiredMap = $config->toRawMap();
+
+        $newContent = $this->buildNewContent($desiredMap);
+
+        $this->assertContentIsLoadable($newContent);
+
+        $this->writeAtomically($newContent);
+    }
+
+    /**
+     * @param array<string, scalar> $desiredMap
+     */
+    private function buildNewContent(array $desiredMap): string
+    {
+        if (!is_file($this->configFilePath)) {
+            return Yaml::dump($desiredMap, 2);
+        }
+
+        $originalContent = file_get_contents($this->configFilePath);
+        if (false === $originalContent) {
+            throw PixelCastConfigException::writeFailed($this->configFilePath, new \RuntimeException(\sprintf('Failed to read "%s" before rewriting.', $this->configFilePath)));
+        }
+
+        $originalLines = preg_split('/(?<=\n)/', $originalContent);
+        if (false === $originalLines) {
+            throw PixelCastConfigException::writeFailed($this->configFilePath, new \RuntimeException(\sprintf('Failed to split "%s" into lines.', $this->configFilePath)));
+        }
+        if ('' === ($originalLines[\count($originalLines) - 1] ?? '')) {
+            array_pop($originalLines);
+        }
+
+        $existingValues = $this->parseExistingValues($originalContent);
+
+        $pendingMap = $desiredMap;
+        $rewrittenLines = [];
+
+        foreach ($originalLines as $line) {
+            $lineEnding = str_ends_with($line, "\n") ? "\n" : '';
+            $stripped = '' === $lineEnding ? $line : substr($line, 0, -1);
+
+            if (1 === preg_match(self::TOP_LEVEL_KEY_LINE_PATTERN, $stripped, $matches)) {
+                $key = $matches['key'];
+                if (\array_key_exists($key, $pendingMap)) {
+                    $desiredValue = $pendingMap[$key];
+                    $valueAlreadyMatches = \array_key_exists($key, $existingValues)
+                        && $existingValues[$key] === $desiredValue;
+
+                    if (!$valueAlreadyMatches) {
+                        $line = \sprintf('%s%s: %s', $matches['indent'], $key, $this->formatScalar($desiredValue)).$lineEnding;
+                    }
+
+                    unset($pendingMap[$key]);
+                    $rewrittenLines[] = $line;
+
+                    continue;
+                }
+            }
+
+            $rewrittenLines[] = $line;
+        }
+
+        $buffer = implode('', $rewrittenLines);
+
+        if ([] !== $pendingMap) {
+            if (!str_ends_with($buffer, "\n\n")) {
+                if (!str_ends_with($buffer, "\n")) {
+                    $buffer .= "\n";
+                }
+                $buffer .= "\n";
+            }
+
+            foreach ($pendingMap as $key => $value) {
+                $buffer .= \sprintf("%s: %s\n", $key, $this->formatScalar($value));
+            }
+        }
+
+        return $this->normalizeTrailingNewline($buffer);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parseExistingValues(string $content): array
+    {
+        try {
+            $parsed = Yaml::parse($content);
+        } catch (ParseException) {
+            return [];
+        }
+
+        if (!\is_array($parsed)) {
+            return [];
+        }
+
+        $stringKeyed = [];
+        foreach ($parsed as $key => $value) {
+            if (\is_string($key)) {
+                $stringKeyed[$key] = $value;
+            }
+        }
+
+        return $stringKeyed;
+    }
+
+    private function normalizeTrailingNewline(string $buffer): string
+    {
+        $trimmed = rtrim($buffer, "\n");
+        if ('' === $trimmed) {
+            return "\n";
+        }
+
+        return $trimmed."\n";
+    }
+
+    private function formatScalar(mixed $value): string
+    {
+        if (\is_int($value)) {
+            return (string) $value;
+        }
+
+        if (\is_string($value)) {
+            $dumped = Yaml::dump($value, 0, 2, Yaml::DUMP_NULL_AS_TILDE);
+
+            return rtrim($dumped, "\n");
+        }
+
+        if (\is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        throw PixelCastConfigException::invalidValue('<scalar>', \sprintf('unsupported scalar type "%s"', get_debug_type($value)));
+    }
+
+    private function assertContentIsLoadable(string $buffer): void
+    {
+        try {
+            $parsed = Yaml::parse($buffer);
+        } catch (ParseException $parseError) {
+            throw PixelCastConfigException::invalidYaml($this->configFilePath, $parseError);
+        }
+
+        PixelCastConfig::fromArray(
+            PixelCastConfig::asStringKeyedMap($parsed, $this->configFilePath),
+        );
+    }
+
+    private function writeAtomically(string $buffer): void
+    {
+        $temporaryPath = $this->configFilePath.'.tmp';
+
+        try {
+            $bytesWritten = @file_put_contents($temporaryPath, $buffer);
+            if (false === $bytesWritten) {
+                throw new \RuntimeException(\sprintf('Failed to write temporary file "%s".', $temporaryPath));
+            }
+
+            $this->filesystem->rename($temporaryPath, $this->configFilePath, true);
+        } catch (IOException|\RuntimeException $writeError) {
+            if (is_file($temporaryPath)) {
+                @unlink($temporaryPath);
+            }
+
+            throw PixelCastConfigException::writeFailed($this->configFilePath, $writeError);
+        }
+    }
+}

--- a/src/Tui/Configuration/ConfigurationFieldValidator.php
+++ b/src/Tui/Configuration/ConfigurationFieldValidator.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Configuration;
+
+final class ConfigurationFieldValidator
+{
+    public const string FIELD_DEVICE_URL = 'device_url';
+    public const string FIELD_WEATHER_INTERVAL = 'weather_interval';
+    public const string FIELD_TRACKER_INTERVAL = 'tracker_interval';
+    public const string FIELD_TRACKED_ASSETS = 'tracked_assets';
+    public const string FIELD_WEATHER_SOURCE = 'weather_source';
+    public const string FIELD_TRACKER_SOURCE = 'tracker_source';
+
+    public function validate(string $fieldId, string $rawValue): ?string
+    {
+        return match ($fieldId) {
+            self::FIELD_DEVICE_URL => $this->validateDeviceUrl($rawValue),
+            self::FIELD_WEATHER_INTERVAL => $this->validatePositiveInteger($rawValue, 'weather_interval'),
+            self::FIELD_TRACKER_INTERVAL => $this->validatePositiveInteger($rawValue, 'tracker_interval'),
+            self::FIELD_TRACKED_ASSETS => $this->validateTrackedAssets($rawValue),
+            self::FIELD_WEATHER_SOURCE => $this->validateNonEmptyString($rawValue, 'weather_source'),
+            self::FIELD_TRACKER_SOURCE => $this->validateNonEmptyString($rawValue, 'tracker_source'),
+            default => \sprintf('Unknown field "%s".', $fieldId),
+        };
+    }
+
+    private function validateDeviceUrl(string $rawValue): ?string
+    {
+        $trimmed = trim($rawValue);
+        if ('' === $trimmed) {
+            return 'device_url must not be empty.';
+        }
+
+        if (false === filter_var($trimmed, \FILTER_VALIDATE_URL)) {
+            return 'device_url must be a valid URL.';
+        }
+
+        return null;
+    }
+
+    private function validatePositiveInteger(string $rawValue, string $fieldLabel): ?string
+    {
+        $trimmed = trim($rawValue);
+        if ('' === $trimmed) {
+            return \sprintf('%s must not be empty.', $fieldLabel);
+        }
+
+        if (!ctype_digit($trimmed) || (int) $trimmed <= 0) {
+            return \sprintf('%s must be a positive integer.', $fieldLabel);
+        }
+
+        return null;
+    }
+
+    private function validateTrackedAssets(string $rawValue): ?string
+    {
+        foreach (explode(',', $rawValue) as $token) {
+            if ('' !== trim($token)) {
+                return null;
+            }
+        }
+
+        return 'tracked_assets must contain at least one asset symbol.';
+    }
+
+    private function validateNonEmptyString(string $rawValue, string $fieldLabel): ?string
+    {
+        if ('' === trim($rawValue)) {
+            return \sprintf('%s must not be empty.', $fieldLabel);
+        }
+
+        return null;
+    }
+}

--- a/src/Tui/Configuration/Panel/ConfigurationPanel.php
+++ b/src/Tui/Configuration/Panel/ConfigurationPanel.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Configuration\Panel;
+
+use App\Config\Exception\PixelCastConfigException;
+use App\Config\PixelCastConfig;
+use App\Config\PixelCastConfigLoader;
+use App\Config\PixelCastConfigWriter;
+use App\Tui\Configuration\ConfigurationFieldValidator;
+use App\Tui\Configuration\SaveOutcome;
+use App\Tui\TerminalSafeText;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\InputWidget;
+use Symfony\Component\Tui\Widget\SettingItem;
+use Symfony\Component\Tui\Widget\SettingsListWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+final class ConfigurationPanel
+{
+    private const string HEADER_TEXT = 'Configuration - [Enter] edit  [S] save  [Esc] back';
+    private const string SEPARATOR_TEXT = '----------------------------------------------------------------';
+    private const string FOOTER_HINT = '[S] Save  [Esc] Cancel';
+
+    private const array FIELD_LABELS = [
+        ConfigurationFieldValidator::FIELD_DEVICE_URL => 'Device URL',
+        ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL => 'Weather interval (s)',
+        ConfigurationFieldValidator::FIELD_TRACKER_INTERVAL => 'Tracker interval (s)',
+        ConfigurationFieldValidator::FIELD_TRACKED_ASSETS => 'Tracked assets',
+        ConfigurationFieldValidator::FIELD_WEATHER_SOURCE => 'Weather source',
+        ConfigurationFieldValidator::FIELD_TRACKER_SOURCE => 'Tracker source',
+    ];
+
+    private const array INT_FIELDS = [
+        ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL,
+        ConfigurationFieldValidator::FIELD_TRACKER_INTERVAL,
+    ];
+
+    private readonly SettingsListWidget $settingsList;
+    private readonly TextWidget $statusLine;
+    private readonly TextWidget $footerHint;
+    private readonly ContainerWidget $container;
+
+    /**
+     * @var array<string, string>
+     */
+    private array $baselineValues;
+
+    /**
+     * @var array<string, string>
+     */
+    private array $workingValues;
+
+    private bool $lastReportedUnsavedFlag = false;
+
+    /**
+     * @var list<callable(bool): void>
+     */
+    private array $unsavedChangesListeners = [];
+
+    public function __construct(
+        private readonly PixelCastConfigLoader $loader,
+        private readonly PixelCastConfigWriter $writer,
+        private readonly ConfigurationFieldValidator $validator,
+    ) {
+        $loaded = $this->loadInitialValues();
+        $this->baselineValues = $loaded['baseline'];
+        $this->workingValues = $loaded['working'];
+
+        $this->settingsList = new SettingsListWidget(
+            items: $this->buildSettingItems(),
+            maxVisible: \count(self::FIELD_LABELS),
+        );
+        $this->statusLine = new TextWidget($loaded['initialStatus']);
+        $this->footerHint = new TextWidget(self::FOOTER_HINT);
+
+        $this->container = new ContainerWidget();
+        $this->container->expandVertically(true);
+        $this->container->add(new TextWidget(self::HEADER_TEXT));
+        $this->container->add(new TextWidget(self::SEPARATOR_TEXT));
+        $this->container->add($this->settingsList);
+        $this->container->add($this->statusLine);
+        $this->container->add($this->footerHint);
+
+        $this->lastReportedUnsavedFlag = $this->hasUnsavedChanges();
+    }
+
+    public function widget(): ContainerWidget
+    {
+        return $this->container;
+    }
+
+    public function selectListWidget(): SettingsListWidget
+    {
+        return $this->settingsList;
+    }
+
+    public function hasUnsavedChanges(): bool
+    {
+        return $this->workingValues !== $this->baselineValues;
+    }
+
+    public function isEditingField(): bool
+    {
+        return [] !== $this->settingsList->all();
+    }
+
+    public function currentDeviceUrl(): string
+    {
+        return $this->workingValues[ConfigurationFieldValidator::FIELD_DEVICE_URL] ?? '';
+    }
+
+    public function onUnsavedChangesChanged(callable $listener): void
+    {
+        $this->unsavedChangesListeners[] = $listener;
+    }
+
+    public function applyFieldEdit(string $fieldId, string $rawValue): ?string
+    {
+        $error = $this->validator->validate($fieldId, $rawValue);
+        if (null !== $error) {
+            $this->statusLine->setText(TerminalSafeText::stripControlBytes($error));
+
+            return $error;
+        }
+
+        $normalizedValue = $this->normalizeFieldValue($fieldId, $rawValue);
+        $this->workingValues[$fieldId] = $normalizedValue;
+        $this->settingsList->updateValue($fieldId, $normalizedValue);
+        $this->statusLine->setText('');
+        $this->notifyUnsavedChangesIfFlipped();
+
+        return null;
+    }
+
+    public function commitSave(): SaveOutcome
+    {
+        if ($this->isEditingField()) {
+            $this->statusLine->setText('Finish editing the current field (Enter or Esc) before saving.');
+
+            return SaveOutcome::ValidationFailed;
+        }
+
+        foreach ($this->workingValues as $fieldId => $rawValue) {
+            $error = $this->validator->validate($fieldId, $rawValue);
+            if (null !== $error) {
+                $this->statusLine->setText(TerminalSafeText::stripControlBytes($error));
+
+                return SaveOutcome::ValidationFailed;
+            }
+        }
+
+        try {
+            $config = PixelCastConfig::fromArray($this->workingValuesAsRawMap());
+        } catch (PixelCastConfigException $configError) {
+            $this->statusLine->setText(TerminalSafeText::stripControlBytes($configError->getMessage()));
+
+            return SaveOutcome::ValidationFailed;
+        }
+
+        try {
+            $this->writer->save($config);
+        } catch (PixelCastConfigException $writeError) {
+            $this->statusLine->setText(TerminalSafeText::stripControlBytes($writeError->getMessage()));
+
+            return SaveOutcome::WriteFailed;
+        }
+
+        $this->baselineValues = $this->workingValues;
+        $this->statusLine->setText('Saved to '.TerminalSafeText::stripControlBytes($this->loader->filePath()));
+        $this->notifyUnsavedChangesIfFlipped();
+
+        return SaveOutcome::Saved;
+    }
+
+    public function discardChanges(): void
+    {
+        $this->workingValues = $this->baselineValues;
+        $this->statusLine->setText('');
+        foreach ($this->workingValues as $fieldId => $value) {
+            $this->settingsList->updateValue($fieldId, $value);
+        }
+        $this->notifyUnsavedChangesIfFlipped();
+    }
+
+    public function statusLineText(): string
+    {
+        return $this->statusLine->getText();
+    }
+
+    /**
+     * @return array{baseline: array<string, string>, working: array<string, string>, initialStatus: string}
+     */
+    private function loadInitialValues(): array
+    {
+        try {
+            $config = $this->loader->load();
+            $baseline = $this->configToWorkingMap($config);
+
+            return [
+                'baseline' => $baseline,
+                'working' => $baseline,
+                'initialStatus' => '',
+            ];
+        } catch (PixelCastConfigException) {
+            $distMap = $this->readDistMap();
+
+            $hasDistDefaults = '' !== ($distMap[ConfigurationFieldValidator::FIELD_DEVICE_URL] ?? '');
+
+            return [
+                'baseline' => [],
+                'working' => $distMap,
+                'initialStatus' => $hasDistDefaults
+                    ? 'Loaded defaults from pixelcast.yaml.dist. Press [S] to create the file.'
+                    : 'No configuration file found. Press [S] to create one.',
+            ];
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function readDistMap(): array
+    {
+        $distPath = $this->loader->filePath().'.dist';
+
+        $emptyMap = array_fill_keys(array_keys(self::FIELD_LABELS), '');
+
+        if (!is_file($distPath)) {
+            return $emptyMap;
+        }
+
+        try {
+            $parsed = Yaml::parseFile($distPath);
+        } catch (ParseException) {
+            return $emptyMap;
+        }
+
+        if (!\is_array($parsed)) {
+            return $emptyMap;
+        }
+
+        $result = $emptyMap;
+        foreach ($parsed as $key => $value) {
+            if (\is_string($key) && \array_key_exists($key, $result)) {
+                $result[$key] = $this->scalarToString($value);
+            }
+        }
+
+        return $result;
+    }
+
+    private function scalarToString(mixed $value): string
+    {
+        if (\is_string($value)) {
+            return $value;
+        }
+        if (\is_int($value) || \is_float($value)) {
+            return (string) $value;
+        }
+        if (\is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return '';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function workingValuesAsRawMap(): array
+    {
+        $raw = [];
+        foreach ($this->workingValues as $fieldId => $value) {
+            $raw[$fieldId] = \in_array($fieldId, self::INT_FIELDS, true) ? (int) $value : $value;
+        }
+
+        return $raw;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function configToWorkingMap(PixelCastConfig $config): array
+    {
+        return [
+            ConfigurationFieldValidator::FIELD_DEVICE_URL => $config->deviceUrl,
+            ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL => (string) $config->weatherInterval,
+            ConfigurationFieldValidator::FIELD_TRACKER_INTERVAL => (string) $config->trackerInterval,
+            ConfigurationFieldValidator::FIELD_TRACKED_ASSETS => implode(', ', $config->trackedAssets),
+            ConfigurationFieldValidator::FIELD_WEATHER_SOURCE => $config->weatherSource,
+            ConfigurationFieldValidator::FIELD_TRACKER_SOURCE => $config->trackerSource,
+        ];
+    }
+
+    /**
+     * @return list<SettingItem>
+     */
+    private function buildSettingItems(): array
+    {
+        $items = [];
+        foreach (self::FIELD_LABELS as $fieldId => $label) {
+            $items[] = new SettingItem(
+                id: $fieldId,
+                label: $label,
+                currentValue: $this->workingValues[$fieldId],
+                submenu: $this->buildInputSubmenuFactory($fieldId),
+            );
+        }
+
+        return $items;
+    }
+
+    private function buildInputSubmenuFactory(string $fieldId): \Closure
+    {
+        return function (string $currentValue, callable $onDone) use ($fieldId): InputWidget {
+            $input = new InputWidget();
+            $input->setPrompt(self::FIELD_LABELS[$fieldId].': ');
+            $input->setValue($currentValue);
+
+            $input->onSubmit(function ($event) use ($fieldId, $onDone, $input): void {
+                $submittedValue = $event->getValue();
+                $error = $this->applyFieldEdit($fieldId, $submittedValue);
+                if (null !== $error) {
+                    $input->setValue($submittedValue);
+
+                    return;
+                }
+
+                $onDone($this->workingValues[$fieldId]);
+            });
+
+            $input->onCancel(static function () use ($onDone): void {
+                $onDone(null);
+            });
+
+            return $input;
+        };
+    }
+
+    private function normalizeFieldValue(string $fieldId, string $rawValue): string
+    {
+        return match ($fieldId) {
+            ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL,
+            ConfigurationFieldValidator::FIELD_TRACKER_INTERVAL => (string) (int) trim($rawValue),
+            ConfigurationFieldValidator::FIELD_TRACKED_ASSETS => $this->normalizeTrackedAssets($rawValue),
+            default => trim($rawValue),
+        };
+    }
+
+    private function normalizeTrackedAssets(string $rawValue): string
+    {
+        $cleaned = [];
+        foreach (explode(',', $rawValue) as $token) {
+            $trimmed = trim($token);
+            if ('' !== $trimmed) {
+                $cleaned[] = $trimmed;
+            }
+        }
+
+        return implode(', ', $cleaned);
+    }
+
+    private function notifyUnsavedChangesIfFlipped(): void
+    {
+        $currentFlag = $this->hasUnsavedChanges();
+        if ($currentFlag === $this->lastReportedUnsavedFlag) {
+            return;
+        }
+
+        $this->lastReportedUnsavedFlag = $currentFlag;
+        foreach ($this->unsavedChangesListeners as $listener) {
+            $listener($currentFlag);
+        }
+    }
+}

--- a/src/Tui/Configuration/SaveOutcome.php
+++ b/src/Tui/Configuration/SaveOutcome.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Configuration;
+
+enum SaveOutcome: string
+{
+    case Saved = 'saved';
+    case ValidationFailed = 'validation-failed';
+    case WriteFailed = 'write-failed';
+}

--- a/src/Tui/StatusBar/StatusBarWidget.php
+++ b/src/Tui/StatusBar/StatusBarWidget.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\StatusBar;
+
+use Symfony\Component\Tui\Widget\TextWidget;
+
+final class StatusBarWidget
+{
+    private const string UNSAVED_INDICATOR = 'UNSAVED CHANGES';
+    private const string SEPARATOR = '   ';
+
+    private readonly TextWidget $textWidget;
+    private string $baseLine = '';
+    private bool $hasUnsavedChanges = false;
+
+    public function __construct()
+    {
+        $this->textWidget = new TextWidget('');
+    }
+
+    public function setBaseLine(string $line): void
+    {
+        if ($this->baseLine === $line) {
+            return;
+        }
+
+        $this->baseLine = $line;
+        $this->refreshText();
+    }
+
+    public function setUnsavedChanges(bool $hasUnsaved): void
+    {
+        if ($this->hasUnsavedChanges === $hasUnsaved) {
+            return;
+        }
+
+        $this->hasUnsavedChanges = $hasUnsaved;
+        $this->refreshText();
+    }
+
+    public function widget(): TextWidget
+    {
+        return $this->textWidget;
+    }
+
+    private function refreshText(): void
+    {
+        $text = $this->baseLine;
+        if ($this->hasUnsavedChanges) {
+            $text .= self::SEPARATOR.self::UNSAVED_INDICATOR;
+        }
+
+        $this->textWidget->setText($text);
+    }
+}

--- a/tests/Command/TuiCommandWiringTest.php
+++ b/tests/Command/TuiCommandWiringTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Tests\Command;
 
 use App\Command\TuiCommand;
+use App\Config\PixelCastConfigLoader;
+use App\Config\PixelCastConfigWriter;
+use App\Tui\Configuration\ConfigurationFieldValidator;
 use App\Tui\ResetSim\ResetSimulatorAction;
 use App\Tui\Scenarios\ScenarioCatalog;
 use App\Tui\Scenarios\ScenarioDispatcher;
@@ -76,5 +79,32 @@ final class TuiCommandWiringTest extends KernelTestCase
         $resetSimulatorAction = self::getContainer()->get(ResetSimulatorAction::class);
 
         self::assertInstanceOf(ResetSimulatorAction::class, $resetSimulatorAction);
+    }
+
+    public function testPixelCastConfigLoaderResolvesFromContainer(): void
+    {
+        self::bootKernel();
+
+        $loader = self::getContainer()->get(PixelCastConfigLoader::class);
+
+        self::assertInstanceOf(PixelCastConfigLoader::class, $loader);
+    }
+
+    public function testPixelCastConfigWriterResolvesFromContainer(): void
+    {
+        self::bootKernel();
+
+        $writer = self::getContainer()->get(PixelCastConfigWriter::class);
+
+        self::assertInstanceOf(PixelCastConfigWriter::class, $writer);
+    }
+
+    public function testConfigurationFieldValidatorResolvesFromContainer(): void
+    {
+        self::bootKernel();
+
+        $validator = self::getContainer()->get(ConfigurationFieldValidator::class);
+
+        self::assertInstanceOf(ConfigurationFieldValidator::class, $validator);
     }
 }

--- a/tests/Config/Fixtures/invalid-syntax.yaml
+++ b/tests/Config/Fixtures/invalid-syntax.yaml
@@ -1,0 +1,6 @@
+device_url: http://pixelcast.test/api
+weather_interval: 120
+tracker_interval: [unterminated
+tracked_assets: BTC, AAPL
+weather_source: openmeteo
+tracker_source: yahoo-finance

--- a/tests/Config/Fixtures/missing-key.yaml
+++ b/tests/Config/Fixtures/missing-key.yaml
@@ -1,0 +1,5 @@
+device_url: http://pixelcast.test/api
+weather_interval: 120
+tracker_interval: 30
+weather_source: openmeteo
+tracker_source: yahoo-finance

--- a/tests/Config/Fixtures/missing-tracked-assets.yaml
+++ b/tests/Config/Fixtures/missing-tracked-assets.yaml
@@ -1,0 +1,14 @@
+# PixelCast device API base URL (no trailing slash).
+device_url: http://pixelcast.test/api
+
+# Polling interval for the weather syncer (seconds).
+weather_interval: 120
+
+# Polling interval for the tracker syncer (seconds).
+tracker_interval: 30
+
+# Identifier of the weather data provider.
+weather_source: openmeteo
+
+# Identifier of the tracker data provider.
+tracker_source: yahoo-finance

--- a/tests/Config/Fixtures/valid.yaml
+++ b/tests/Config/Fixtures/valid.yaml
@@ -1,0 +1,7 @@
+# Sample configuration used by PixelCastConfigLoaderTest.
+device_url: http://pixelcast.test/api
+weather_interval: 120
+tracker_interval: 30
+tracked_assets: BTC,  AAPL ,SPY ,, ETH
+weather_source: openmeteo
+tracker_source: yahoo-finance

--- a/tests/Config/Fixtures/with-comments.yaml
+++ b/tests/Config/Fixtures/with-comments.yaml
@@ -1,0 +1,17 @@
+# PixelCast device API base URL (no trailing slash).
+device_url: http://pixelcast.test/api
+
+# Polling interval for the weather syncer (seconds).
+weather_interval: 120
+
+# Polling interval for the tracker syncer (seconds).
+tracker_interval: 30
+
+# Comma-separated list of tracked asset symbols.
+tracked_assets: BTC, AAPL, SPY, ETH
+
+# Identifier of the weather data provider.
+weather_source: openmeteo
+
+# Identifier of the tracker data provider.
+tracker_source: yahoo-finance

--- a/tests/Config/PixelCastConfigLoaderTest.php
+++ b/tests/Config/PixelCastConfigLoaderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Config;
+
+use App\Config\Exception\PixelCastConfigException;
+use App\Config\PixelCastConfig;
+use App\Config\PixelCastConfigLoader;
+use PHPUnit\Framework\TestCase;
+
+final class PixelCastConfigLoaderTest extends TestCase
+{
+    private const string FIXTURES_DIR = __DIR__.'/Fixtures';
+
+    public function testLoadReturnsConfigFromValidFile(): void
+    {
+        $loader = new PixelCastConfigLoader(self::FIXTURES_DIR.'/valid.yaml');
+
+        $config = $loader->load();
+
+        self::assertSame('http://pixelcast.test/api', $config->deviceUrl);
+        self::assertSame(120, $config->weatherInterval);
+        self::assertSame(30, $config->trackerInterval);
+        self::assertSame('openmeteo', $config->weatherSource);
+        self::assertSame('yahoo-finance', $config->trackerSource);
+    }
+
+    public function testLoadThrowsWhenFileMissing(): void
+    {
+        $missingPath = self::FIXTURES_DIR.'/does-not-exist.yaml';
+        $loader = new PixelCastConfigLoader($missingPath);
+
+        self::assertFalse($loader->exists());
+        self::assertSame($missingPath, $loader->filePath());
+
+        $this->expectException(PixelCastConfigException::class);
+        $this->expectExceptionMessage('not found');
+
+        $loader->load();
+    }
+
+    public function testLoadThrowsOnSyntaxError(): void
+    {
+        $loader = new PixelCastConfigLoader(self::FIXTURES_DIR.'/invalid-syntax.yaml');
+
+        $this->expectException(PixelCastConfigException::class);
+        $this->expectExceptionMessage('Failed to parse PixelCast config');
+
+        $loader->load();
+    }
+
+    public function testLoadThrowsOnMissingKey(): void
+    {
+        $loader = new PixelCastConfigLoader(self::FIXTURES_DIR.'/missing-key.yaml');
+
+        $this->expectException(PixelCastConfigException::class);
+        $this->expectExceptionMessage('tracked_assets');
+
+        $loader->load();
+    }
+
+    public function testLoadParsesTrackedAssetsAsTrimmedList(): void
+    {
+        $loader = new PixelCastConfigLoader(self::FIXTURES_DIR.'/valid.yaml');
+
+        $config = $loader->load();
+
+        self::assertSame(['BTC', 'AAPL', 'SPY', 'ETH'], $config->trackedAssets);
+    }
+
+    public function testToRawMapJoinsTrackedAssetsWithCommaSpace(): void
+    {
+        $config = new PixelCastConfig(
+            deviceUrl: 'http://pixelcast.test/api',
+            weatherInterval: 120,
+            trackerInterval: 30,
+            trackedAssets: ['BTC', 'AAPL', 'SPY', 'ETH'],
+            weatherSource: 'openmeteo',
+            trackerSource: 'yahoo-finance',
+        );
+
+        $rawMap = $config->toRawMap();
+
+        self::assertSame('BTC, AAPL, SPY, ETH', $rawMap['tracked_assets']);
+        self::assertSame(120, $rawMap['weather_interval']);
+        self::assertSame('http://pixelcast.test/api', $rawMap['device_url']);
+    }
+}

--- a/tests/Config/PixelCastConfigWriterTest.php
+++ b/tests/Config/PixelCastConfigWriterTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Config;
+
+use App\Config\Exception\PixelCastConfigException;
+use App\Config\PixelCastConfig;
+use App\Config\PixelCastConfigLoader;
+use App\Config\PixelCastConfigWriter;
+use PHPUnit\Framework\TestCase;
+
+final class PixelCastConfigWriterTest extends TestCase
+{
+    private const string FIXTURES_DIR = __DIR__.'/Fixtures';
+
+    private string $temporaryConfigPath;
+
+    protected function setUp(): void
+    {
+        $this->temporaryConfigPath = \sprintf(
+            '%s/pixelcast-config-writer-%s.yaml',
+            sys_get_temp_dir(),
+            bin2hex(random_bytes(8)),
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([$this->temporaryConfigPath, $this->temporaryConfigPath.'.tmp'] as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+    }
+
+    public function testSaveKeepsCommentsAndBlankLines(): void
+    {
+        $originalContent = $this->copyFixtureToTemp('with-comments.yaml');
+        $config = new PixelCastConfigLoader($this->temporaryConfigPath)->load();
+        $writer = new PixelCastConfigWriter($this->temporaryConfigPath);
+
+        $writer->save($config);
+
+        self::assertSame($originalContent, file_get_contents($this->temporaryConfigPath));
+    }
+
+    public function testSaveUpdatesChangedValueInPlace(): void
+    {
+        $this->copyFixtureToTemp('with-comments.yaml');
+        $originalLines = file($this->temporaryConfigPath);
+        self::assertIsArray($originalLines);
+
+        $loaded = new PixelCastConfigLoader($this->temporaryConfigPath)->load();
+        $updated = new PixelCastConfig(
+            deviceUrl: $loaded->deviceUrl,
+            weatherInterval: 600,
+            trackerInterval: $loaded->trackerInterval,
+            trackedAssets: $loaded->trackedAssets,
+            weatherSource: $loaded->weatherSource,
+            trackerSource: $loaded->trackerSource,
+        );
+
+        new PixelCastConfigWriter($this->temporaryConfigPath)->save($updated);
+
+        $rewrittenLines = file($this->temporaryConfigPath);
+        self::assertIsArray($rewrittenLines);
+        self::assertCount(\count($originalLines), $rewrittenLines);
+
+        foreach ($originalLines as $index => $originalLine) {
+            if (str_starts_with($originalLine, 'weather_interval:')) {
+                self::assertSame("weather_interval: 600\n", $rewrittenLines[$index]);
+
+                continue;
+            }
+            self::assertSame($originalLine, $rewrittenLines[$index], \sprintf('Line %d changed unexpectedly.', $index + 1));
+        }
+    }
+
+    public function testSaveAppendsNewKeyAtEndOfFile(): void
+    {
+        $this->copyFixtureToTemp('missing-tracked-assets.yaml');
+
+        $config = new PixelCastConfig(
+            deviceUrl: 'http://pixelcast.test/api',
+            weatherInterval: 120,
+            trackerInterval: 30,
+            trackedAssets: ['BTC', 'AAPL', 'SPY', 'ETH'],
+            weatherSource: 'openmeteo',
+            trackerSource: 'yahoo-finance',
+        );
+
+        new PixelCastConfigWriter($this->temporaryConfigPath)->save($config);
+
+        $rewrittenLines = file($this->temporaryConfigPath);
+        self::assertIsArray($rewrittenLines);
+
+        $lastLine = $rewrittenLines[\count($rewrittenLines) - 1];
+        $beforeLast = $rewrittenLines[\count($rewrittenLines) - 2];
+
+        self::assertSame("tracked_assets: 'BTC, AAPL, SPY, ETH'\n", $lastLine);
+        self::assertSame("\n", $beforeLast);
+
+        $reloaded = new PixelCastConfigLoader($this->temporaryConfigPath)->load();
+        self::assertSame(['BTC', 'AAPL', 'SPY', 'ETH'], $reloaded->trackedAssets);
+    }
+
+    public function testSaveDoesNotTouchUnchangedKeys(): void
+    {
+        $originalContent = $this->copyFixtureToTemp('with-comments.yaml');
+        $loader = new PixelCastConfigLoader($this->temporaryConfigPath);
+        $config = $loader->load();
+
+        new PixelCastConfigWriter($this->temporaryConfigPath)->save($config);
+
+        self::assertSame($originalContent, file_get_contents($this->temporaryConfigPath));
+    }
+
+    public function testSaveFailsBeforeWriteWhenResultWouldBeInvalid(): void
+    {
+        $originalContent = $this->copyFixtureToTemp('with-comments.yaml');
+        $originalMtime = filemtime($this->temporaryConfigPath);
+        self::assertNotFalse($originalMtime);
+
+        $invalidConfig = $this->buildInvalidConfigViaReflection();
+
+        $this->expectException(PixelCastConfigException::class);
+
+        try {
+            new PixelCastConfigWriter($this->temporaryConfigPath)->save($invalidConfig);
+        } finally {
+            clearstatcache(true, $this->temporaryConfigPath);
+            self::assertSame($originalContent, file_get_contents($this->temporaryConfigPath));
+            self::assertSame($originalMtime, filemtime($this->temporaryConfigPath));
+            self::assertFalse(is_file($this->temporaryConfigPath.'.tmp'));
+        }
+    }
+
+    public function testSaveCreatesFileWhenAbsent(): void
+    {
+        self::assertFalse(is_file($this->temporaryConfigPath));
+
+        $distConfig = new PixelCastConfigLoader(\dirname(__DIR__, 2).'/pixelcast.yaml.dist')->load();
+
+        new PixelCastConfigWriter($this->temporaryConfigPath)->save($distConfig);
+
+        self::assertTrue(is_file($this->temporaryConfigPath));
+
+        $reloaded = new PixelCastConfigLoader($this->temporaryConfigPath)->load();
+        self::assertEquals($distConfig, $reloaded);
+    }
+
+    public function testSaveQuotesValuesContainingColons(): void
+    {
+        $this->copyFixtureToTemp('with-comments.yaml');
+
+        $loaded = new PixelCastConfigLoader($this->temporaryConfigPath)->load();
+        $updated = new PixelCastConfig(
+            deviceUrl: 'http://example.test/api',
+            weatherInterval: $loaded->weatherInterval,
+            trackerInterval: $loaded->trackerInterval,
+            trackedAssets: $loaded->trackedAssets,
+            weatherSource: $loaded->weatherSource,
+            trackerSource: $loaded->trackerSource,
+        );
+
+        new PixelCastConfigWriter($this->temporaryConfigPath)->save($updated);
+
+        $reloaded = new PixelCastConfigLoader($this->temporaryConfigPath)->load();
+        self::assertSame('http://example.test/api', $reloaded->deviceUrl);
+    }
+
+    private function copyFixtureToTemp(string $fixtureName): string
+    {
+        $sourcePath = self::FIXTURES_DIR.'/'.$fixtureName;
+        $content = file_get_contents($sourcePath);
+        self::assertNotFalse($content);
+
+        $written = file_put_contents($this->temporaryConfigPath, $content);
+        self::assertNotFalse($written);
+
+        return $content;
+    }
+
+    private function buildInvalidConfigViaReflection(): PixelCastConfig
+    {
+        $reflection = new \ReflectionClass(PixelCastConfig::class);
+        $instance = $reflection->newInstanceWithoutConstructor();
+
+        foreach ([
+            'deviceUrl' => 'http://pixelcast.test/api',
+            'weatherInterval' => -1,
+            'trackerInterval' => 30,
+            'trackedAssets' => ['BTC'],
+            'weatherSource' => 'openmeteo',
+            'trackerSource' => 'yahoo-finance',
+        ] as $propertyName => $value) {
+            $property = $reflection->getProperty($propertyName);
+            $property->setValue($instance, $value);
+        }
+
+        return $instance;
+    }
+}

--- a/tests/Tui/Configuration/ConfigurationFieldValidatorTest.php
+++ b/tests/Tui/Configuration/ConfigurationFieldValidatorTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Configuration;
+
+use App\Tui\Configuration\ConfigurationFieldValidator;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigurationFieldValidatorTest extends TestCase
+{
+    private ConfigurationFieldValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new ConfigurationFieldValidator();
+    }
+
+    public function testDeviceUrlAcceptsValidUrl(): void
+    {
+        self::assertNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_DEVICE_URL,
+            'http://pixelcast.local/api',
+        ));
+    }
+
+    public function testDeviceUrlRejectsEmptyValue(): void
+    {
+        self::assertNotNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_DEVICE_URL,
+            '',
+        ));
+    }
+
+    public function testDeviceUrlRejectsWhitespaceOnlyValue(): void
+    {
+        self::assertNotNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_DEVICE_URL,
+            '    ',
+        ));
+    }
+
+    public function testDeviceUrlRejectsMalformedUrl(): void
+    {
+        self::assertNotNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_DEVICE_URL,
+            'not-a-url',
+        ));
+    }
+
+    public function testWeatherIntervalAcceptsPositiveInteger(): void
+    {
+        self::assertNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL,
+            '300',
+        ));
+    }
+
+    public function testWeatherIntervalRejectsZero(): void
+    {
+        self::assertNotNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL,
+            '0',
+        ));
+    }
+
+    public function testWeatherIntervalRejectsNegativeValue(): void
+    {
+        self::assertNotNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL,
+            '-5',
+        ));
+    }
+
+    public function testWeatherIntervalRejectsNonNumericValue(): void
+    {
+        self::assertNotNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL,
+            '30s',
+        ));
+    }
+
+    public function testWeatherIntervalRejectsEmptyValue(): void
+    {
+        self::assertNotNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL,
+            '',
+        ));
+    }
+
+    public function testTrackerIntervalAcceptsPositiveInteger(): void
+    {
+        self::assertNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_TRACKER_INTERVAL,
+            '60',
+        ));
+    }
+
+    public function testTrackerIntervalRejectsZero(): void
+    {
+        self::assertNotNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_TRACKER_INTERVAL,
+            '0',
+        ));
+    }
+
+    public function testTrackedAssetsAcceptsCommaSeparatedList(): void
+    {
+        self::assertNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_TRACKED_ASSETS,
+            'BTC, AAPL, SPY',
+        ));
+    }
+
+    public function testTrackedAssetsAcceptsSingleToken(): void
+    {
+        self::assertNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_TRACKED_ASSETS,
+            'BTC',
+        ));
+    }
+
+    public function testTrackedAssetsRejectsEmptyValue(): void
+    {
+        self::assertNotNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_TRACKED_ASSETS,
+            '',
+        ));
+    }
+
+    public function testTrackedAssetsRejectsOnlyCommasAndWhitespace(): void
+    {
+        self::assertNotNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_TRACKED_ASSETS,
+            ' , ,  ,',
+        ));
+    }
+
+    public function testWeatherSourceAcceptsNonEmptyValue(): void
+    {
+        self::assertNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_WEATHER_SOURCE,
+            'openmeteo',
+        ));
+    }
+
+    public function testWeatherSourceRejectsEmptyValue(): void
+    {
+        self::assertNotNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_WEATHER_SOURCE,
+            '',
+        ));
+    }
+
+    public function testWeatherSourceRejectsWhitespaceOnlyValue(): void
+    {
+        self::assertNotNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_WEATHER_SOURCE,
+            "   \t",
+        ));
+    }
+
+    public function testTrackerSourceAcceptsNonEmptyValue(): void
+    {
+        self::assertNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_TRACKER_SOURCE,
+            'yahoo-finance',
+        ));
+    }
+
+    public function testTrackerSourceRejectsEmptyValue(): void
+    {
+        self::assertNotNull($this->validator->validate(
+            ConfigurationFieldValidator::FIELD_TRACKER_SOURCE,
+            '',
+        ));
+    }
+
+    public function testUnknownFieldReturnsError(): void
+    {
+        self::assertNotNull($this->validator->validate('unknown_field', 'value'));
+    }
+}

--- a/tests/Tui/Configuration/ConfigurationFlowSmokeTest.php
+++ b/tests/Tui/Configuration/ConfigurationFlowSmokeTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Configuration;
+
+use App\Command\TuiView;
+use App\Config\PixelCastConfigLoader;
+use App\Config\PixelCastConfigWriter;
+use App\Tui\Configuration\ConfigurationFieldValidator;
+use App\Tui\Configuration\Panel\ConfigurationPanel;
+use App\Tui\Configuration\SaveOutcome;
+use App\Tui\Menu\TuiMenuFactory;
+use App\Tui\Menu\TuiMenuItem;
+use App\Tui\TuiMode;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\Process;
+
+final class ConfigurationFlowSmokeTest extends KernelTestCase
+{
+    private string $temporaryConfigPath;
+
+    protected function setUp(): void
+    {
+        $temporaryPath = tempnam(sys_get_temp_dir(), 'pixelcast-');
+        self::assertNotFalse($temporaryPath);
+        $this->temporaryConfigPath = $temporaryPath;
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([$this->temporaryConfigPath, $this->temporaryConfigPath.'.tmp'] as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+    }
+
+    public function testProdMenuExposesConfigurationItemWithExpectedShortcut(): void
+    {
+        $items = TuiMenuFactory::buildForMode(TuiMode::Prod);
+
+        $configurationItem = null;
+        foreach ($items as $item) {
+            if ('configuration' === $item->value) {
+                $configurationItem = $item;
+
+                break;
+            }
+        }
+
+        self::assertInstanceOf(TuiMenuItem::class, $configurationItem);
+        self::assertSame('2', $configurationItem->shortcut);
+        self::assertSame('Configuration', $configurationItem->label);
+    }
+
+    public function testTuiViewConfigurationCaseExists(): void
+    {
+        self::assertSame('configuration', TuiView::Configuration->value);
+    }
+
+    public function testEndToEndSaveRoundTripPersistsValueAndPreservesLeadingComment(): void
+    {
+        $distPath = $this->projectRoot().'/pixelcast.yaml.dist';
+        self::assertTrue(is_file($distPath), 'pixelcast.yaml.dist must exist at the project root.');
+
+        $distContent = file_get_contents($distPath);
+        self::assertIsString($distContent);
+
+        $bytesWritten = file_put_contents($this->temporaryConfigPath, $distContent);
+        self::assertNotFalse($bytesWritten);
+
+        $loader = new PixelCastConfigLoader($this->temporaryConfigPath);
+        $writer = new PixelCastConfigWriter($this->temporaryConfigPath);
+        $validator = new ConfigurationFieldValidator();
+
+        $panel = new ConfigurationPanel($loader, $writer, $validator);
+
+        self::assertFalse($panel->hasUnsavedChanges());
+
+        $error = $panel->applyFieldEdit(ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL, '900');
+        self::assertNull($error);
+        self::assertTrue($panel->hasUnsavedChanges());
+
+        $outcome = $panel->commitSave();
+        self::assertSame(SaveOutcome::Saved, $outcome);
+        self::assertFalse($panel->hasUnsavedChanges());
+
+        $reloadedConfig = new PixelCastConfigLoader($this->temporaryConfigPath)->load();
+        self::assertSame(900, $reloadedConfig->weatherInterval);
+
+        $distLeadingComment = $this->firstNonBlankLine($distContent);
+        $rewrittenContent = file_get_contents($this->temporaryConfigPath);
+        self::assertIsString($rewrittenContent);
+        $rewrittenLeadingComment = $this->firstNonBlankLine($rewrittenContent);
+
+        self::assertNotSame('', $distLeadingComment);
+        self::assertStringStartsWith('#', $distLeadingComment);
+        self::assertSame($distLeadingComment, $rewrittenLeadingComment);
+    }
+
+    public function testRuntimeConfigPathIsGitignored(): void
+    {
+        $gitBinary = new ExecutableFinder()->find('git');
+        if (null === $gitBinary) {
+            self::markTestSkipped('git is not available on this host.');
+        }
+
+        $projectRoot = $this->projectRoot();
+
+        $statusProcess = new Process([$gitBinary, 'rev-parse', '--is-inside-work-tree'], $projectRoot);
+        $statusProcess->run();
+        if (0 !== $statusProcess->getExitCode()) {
+            self::markTestSkipped(\sprintf('git refused to operate in "%s": %s', $projectRoot, trim($statusProcess->getErrorOutput())));
+        }
+
+        $process = new Process([$gitBinary, 'check-ignore', '--quiet', 'pixelcast.yaml'], $projectRoot);
+        $process->run();
+
+        self::assertSame(
+            0,
+            $process->getExitCode(),
+            \sprintf('pixelcast.yaml should be gitignored. git output: %s', $process->getErrorOutput()),
+        );
+    }
+
+    private function projectRoot(): string
+    {
+        self::bootKernel();
+
+        /** @var string $projectDir */
+        $projectDir = self::getContainer()->getParameter('kernel.project_dir');
+
+        return $projectDir;
+    }
+
+    private function firstNonBlankLine(string $content): string
+    {
+        $lines = preg_split('/\r?\n/', $content);
+        if (false === $lines) {
+            return '';
+        }
+
+        foreach ($lines as $line) {
+            if ('' !== trim($line)) {
+                return $line;
+            }
+        }
+
+        return '';
+    }
+}

--- a/tests/Tui/Configuration/Panel/ConfigurationPanelTest.php
+++ b/tests/Tui/Configuration/Panel/ConfigurationPanelTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Configuration\Panel;
+
+use App\Config\PixelCastConfigLoader;
+use App\Config\PixelCastConfigWriter;
+use App\Tui\Configuration\ConfigurationFieldValidator;
+use App\Tui\Configuration\Panel\ConfigurationPanel;
+use App\Tui\Configuration\SaveOutcome;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\SettingItem;
+
+final class ConfigurationPanelTest extends TestCase
+{
+    private const string FIXTURE_PATH = __DIR__.'/../../../Config/Fixtures/with-comments.yaml';
+
+    private string $temporaryConfigPath;
+
+    protected function setUp(): void
+    {
+        $this->temporaryConfigPath = \sprintf(
+            '%s/configuration-panel-%s.yaml',
+            sys_get_temp_dir(),
+            bin2hex(random_bytes(8)),
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([$this->temporaryConfigPath, $this->temporaryConfigPath.'.tmp'] as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+    }
+
+    public function testWidgetIsContainerWidget(): void
+    {
+        $panel = $this->buildPanelWithFixture();
+
+        self::assertInstanceOf(ContainerWidget::class, $panel->widget());
+    }
+
+    public function testInitialStateMatchesLoadedConfig(): void
+    {
+        $this->copyFixture();
+        $expectedConfig = new PixelCastConfigLoader($this->temporaryConfigPath)->load();
+        $panel = $this->buildPanel();
+
+        self::assertSame($expectedConfig->deviceUrl, $panel->currentDeviceUrl());
+        self::assertFalse($panel->hasUnsavedChanges());
+    }
+
+    public function testEditingFieldFlipsUnsavedFlag(): void
+    {
+        $panel = $this->buildPanelWithFixture();
+
+        $error = $panel->applyFieldEdit(ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL, '600');
+
+        self::assertNull($error);
+        self::assertTrue($panel->hasUnsavedChanges());
+    }
+
+    public function testDiscardChangesRestoresBaseline(): void
+    {
+        $panel = $this->buildPanelWithFixture();
+
+        $panel->applyFieldEdit(ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL, '900');
+        self::assertTrue($panel->hasUnsavedChanges());
+
+        $panel->discardChanges();
+
+        self::assertFalse($panel->hasUnsavedChanges());
+    }
+
+    public function testCommitSavePersistsToFile(): void
+    {
+        $panel = $this->buildPanelWithFixture();
+
+        $panel->applyFieldEdit(ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL, '600');
+
+        $outcome = $panel->commitSave();
+
+        self::assertSame(SaveOutcome::Saved, $outcome);
+        self::assertFalse($panel->hasUnsavedChanges());
+
+        $reloaded = new PixelCastConfigLoader($this->temporaryConfigPath)->load();
+        self::assertSame(600, $reloaded->weatherInterval);
+    }
+
+    public function testCommitSaveReportsValidationFailureWithoutWriting(): void
+    {
+        $panel = $this->buildPanelWithFixture();
+        $originalContent = file_get_contents($this->temporaryConfigPath);
+        self::assertIsString($originalContent);
+
+        $error = $panel->applyFieldEdit(ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL, 'not-a-number');
+
+        self::assertNotNull($error);
+        self::assertFalse($panel->hasUnsavedChanges());
+        self::assertSame($originalContent, file_get_contents($this->temporaryConfigPath));
+        self::assertNotSame('', $panel->statusLineText());
+    }
+
+    public function testApplyFieldEditRejectsInvalidValue(): void
+    {
+        $panel = $this->buildPanelWithFixture();
+
+        $error = $panel->applyFieldEdit(ConfigurationFieldValidator::FIELD_DEVICE_URL, 'not a url');
+
+        self::assertNotNull($error);
+        self::assertFalse($panel->hasUnsavedChanges());
+        self::assertNotSame('', $panel->statusLineText());
+    }
+
+    public function testUnsavedChangesListenerFiresOnTransition(): void
+    {
+        $panel = $this->buildPanelWithFixture();
+
+        $observed = [];
+        $panel->onUnsavedChangesChanged(static function (bool $hasUnsaved) use (&$observed): void {
+            $observed[] = $hasUnsaved;
+        });
+
+        $panel->applyFieldEdit(ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL, '777');
+        $panel->discardChanges();
+
+        self::assertSame([true, false], $observed);
+    }
+
+    public function testBootstrapFromDistMarksPanelAsUnsaved(): void
+    {
+        $distPath = $this->temporaryConfigPath.'.dist';
+        copy(self::FIXTURE_PATH, $distPath);
+
+        try {
+            $panel = $this->buildPanel();
+
+            self::assertTrue($panel->hasUnsavedChanges());
+            self::assertNotSame('', $panel->currentDeviceUrl());
+        } finally {
+            @unlink($distPath);
+        }
+    }
+
+    public function testCommitSaveAfterBootstrapCreatesRuntimeFile(): void
+    {
+        $distPath = $this->temporaryConfigPath.'.dist';
+        copy(self::FIXTURE_PATH, $distPath);
+
+        try {
+            $panel = $this->buildPanel();
+            self::assertFalse(is_file($this->temporaryConfigPath));
+
+            $outcome = $panel->commitSave();
+
+            self::assertSame(SaveOutcome::Saved, $outcome);
+            self::assertTrue(is_file($this->temporaryConfigPath));
+            self::assertFalse($panel->hasUnsavedChanges());
+        } finally {
+            @unlink($distPath);
+        }
+    }
+
+    public function testCommitSaveRejectsWhenEditingFieldIsOpen(): void
+    {
+        $panel = $this->buildPanelWithFixture();
+
+        $this->openFieldEditor($panel, ConfigurationFieldValidator::FIELD_WEATHER_INTERVAL);
+
+        $outcome = $panel->commitSave();
+
+        self::assertSame(SaveOutcome::ValidationFailed, $outcome);
+        self::assertTrue($panel->isEditingField());
+        self::assertStringContainsString('Finish editing', $panel->statusLineText());
+    }
+
+    private function buildPanelWithFixture(): ConfigurationPanel
+    {
+        $this->copyFixture();
+
+        return $this->buildPanel();
+    }
+
+    private function buildPanel(): ConfigurationPanel
+    {
+        $loader = new PixelCastConfigLoader($this->temporaryConfigPath);
+        $writer = new PixelCastConfigWriter($this->temporaryConfigPath);
+        $validator = new ConfigurationFieldValidator();
+
+        return new ConfigurationPanel($loader, $writer, $validator);
+    }
+
+    private function copyFixture(): void
+    {
+        $content = file_get_contents(self::FIXTURE_PATH);
+        self::assertNotFalse($content);
+        $written = file_put_contents($this->temporaryConfigPath, $content);
+        self::assertNotFalse($written);
+    }
+
+    private function openFieldEditor(ConfigurationPanel $panel, string $fieldId): void
+    {
+        $settingsList = $panel->selectListWidget();
+        /** @var list<SettingItem> $items */
+        $items = new \ReflectionProperty($settingsList, 'items')->getValue($settingsList);
+
+        $targetIndex = null;
+        foreach ($items as $index => $item) {
+            if ($item->getId() === $fieldId) {
+                $targetIndex = $index;
+                break;
+            }
+        }
+        self::assertNotNull($targetIndex, \sprintf('Setting item "%s" not found.', $fieldId));
+
+        new \ReflectionProperty($settingsList, 'selectedIndex')->setValue($settingsList, $targetIndex);
+        new \ReflectionMethod($settingsList, 'activateCurrentItem')->invoke($settingsList);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Symfony config loader plus an interactive `[2] Configuration` editor in the prod-mode TUI shell. Edits are written back to `pixelcast.yaml` via a line-based patcher that preserves comments, blank lines, and the position of unchanged keys; the status bar surfaces an `UNSAVED CHANGES` indicator while pending edits exist; every field is checked by an inline validator before save.

Closes #32

## Review follow-ups (out of scope for this PR)

Six lower-severity items from the in-process review remain. They are intentionally deferred to keep this PR scoped — open a follow-up issue if any of them block adoption:

- Appended (new-schema) keys land bare in an existing pixelcast.yaml; existing keys carry their original comment. Consider attaching an optional comment per key in PixelCastConfig::toRawMap().
- Runtime config path is autowired in two places (loader + writer). Bind it once via a parameter or have the writer reuse the loader's filePath().
- validateDeviceUrl uses FILTER_VALIDATE_URL alone; could tighten to http(s) only and reject trailing slash (matches the dist comment).
- SEPARATOR_TEXT is a hard-coded 64-char ruler in ConfigurationPanel; not layout-aware.
- scalarToString() (ConfigurationPanel) and formatScalar() (PixelCastConfigWriter) duplicate near-identical YAML scalar formatting.
- PixelCastConfig::asStringKeyedMap() is a static coercion helper that fits better on the loader or folded into fromArray().

Test pinning consistency between ConfigurationFieldValidator and PixelCastConfig::fromArray rules is also worth adding but did not fit this scope.