### PR TITLE
feat(tui): prod-mode Device Status panel polling /api/stats (#33)

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -53,5 +53,9 @@ services:
 
     App\Tui\Scenarios\Transport\ScenarioTransport: '@App\Tui\Scenarios\Transport\ScenarioHttpClient'
 
+    App\Tui\DeviceStatus\StatsHttpClient: ~
+
+    App\Tui\DeviceStatus\StatsTransport: '@App\Tui\DeviceStatus\StatsHttpClient'
+
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -9,6 +9,9 @@ use App\Config\PixelCastConfigWriter;
 use App\Tui\Configuration\ConfigurationFieldValidator;
 use App\Tui\Configuration\Panel\ConfigurationPanel;
 use App\Tui\Configuration\SaveOutcome;
+use App\Tui\DeviceStatus\Panel\DeviceStatusPanel;
+use App\Tui\DeviceStatus\StatsPoller;
+use App\Tui\DeviceStatus\StatsTransport;
 use App\Tui\Inspector\InspectorPoller;
 use App\Tui\Inspector\InspectorTransport;
 use App\Tui\Inspector\RequestLogPanel;
@@ -61,6 +64,7 @@ final class TuiCommand extends Command
         private readonly PixelCastConfigLoader $pixelCastConfigLoader,
         private readonly PixelCastConfigWriter $pixelCastConfigWriter,
         private readonly ConfigurationFieldValidator $configurationFieldValidator,
+        private readonly StatsTransport $statsHttpClient,
     ) {
         parent::__construct();
     }
@@ -105,12 +109,21 @@ final class TuiCommand extends Command
         }
 
         $configurationPanel = null;
+        $statsPoller = null;
+        $deviceStatusPanel = null;
         if (TuiMode::Prod === $mode) {
             $configurationPanel = new ConfigurationPanel(
                 $this->pixelCastConfigLoader,
                 $this->pixelCastConfigWriter,
                 $this->configurationFieldValidator,
             );
+
+            $effectiveDeviceUrl = '' !== $configurationPanel->currentDeviceUrl()
+                ? $configurationPanel->currentDeviceUrl()
+                : $this->deviceBaseUrl;
+            $statsPoller = new StatsPoller($this->statsHttpClient, $effectiveDeviceUrl);
+            $deviceStatusPanel = new DeviceStatusPanel();
+            $deviceStatusPanel->update($statsPoller->poll(), busy: false);
         }
 
         $viewContainer = new ContainerWidget();
@@ -144,6 +157,14 @@ final class TuiCommand extends Command
                 $statusBar->setUnsavedChanges($hasUnsaved);
                 $tui->requestRender();
             });
+        }
+        if (null !== $statsPoller) {
+            $viewWidgets[TuiView::DeviceStatus->value] = $deviceStatusPanel->widget();
+            $tui->onTick($this->buildStatsTickListener(
+                $tui,
+                $statsPoller,
+                $deviceStatusPanel,
+            ));
         }
 
         if (null !== $inspectorPoller) {
@@ -253,6 +274,18 @@ final class TuiCommand extends Command
             });
         }
 
+        if (null !== $deviceStatusPanel) {
+            // DeviceStatusPanel is read-only and exposes no focusable widget, so the
+            // cancel handler keys off the active view instead of an event target.
+            $tui->addListener(function (CancelEvent $event) use ($tui, $viewContainer, $viewWidgets): void {
+                if (TuiView::DeviceStatus !== $this->currentView) {
+                    return;
+                }
+
+                $this->switchView($tui, $viewContainer, TuiView::Main, $viewWidgets);
+            });
+        }
+
         $tui->addListener(function (InputEvent $event) use ($tui, $statusBar, $configurationPanel, $mode, $reachabilityResult): void {
             $rawInput = $event->getData();
             if ('q' === $rawInput || 'Q' === $rawInput) {
@@ -329,6 +362,26 @@ final class TuiCommand extends Command
             $snapshot = $inspectorPoller->getLatestSnapshot();
             $stateInspectorPanel->update($snapshot, busy: false);
             $requestLogPanel->update($snapshot, busy: false);
+            $tui->requestRender();
+        };
+    }
+
+    private function buildStatsTickListener(
+        Tui $tui,
+        StatsPoller $statsPoller,
+        DeviceStatusPanel $deviceStatusPanel,
+    ): callable {
+        return static function (TickEvent $event) use (
+            $tui,
+            $statsPoller,
+            $deviceStatusPanel,
+        ): void {
+            if (!$statsPoller->pollIfDue($event->getDeltaTime())) {
+                return;
+            }
+
+            $event->setBusy(true);
+            $deviceStatusPanel->update($statsPoller->getLatestSnapshot(), busy: false);
             $tui->requestRender();
         };
     }

--- a/src/Command/TuiView.php
+++ b/src/Command/TuiView.php
@@ -11,4 +11,5 @@ enum TuiView: string
     case SyncNow = 'sync-now';
     case ResetSim = 'reset-sim';
     case Configuration = 'configuration';
+    case DeviceStatus = 'device-status';
 }

--- a/src/Tui/DeviceStatus/Panel/DeviceStatusPanel.php
+++ b/src/Tui/DeviceStatus/Panel/DeviceStatusPanel.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceStatus\Panel;
+
+use App\Tui\DeviceStatus\StatsFormatter;
+use App\Tui\DeviceStatus\StatsSnapshot;
+use Symfony\Component\Tui\Widget\AbstractWidget;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+
+final class DeviceStatusPanel
+{
+    private const string HEADER_BASE = 'Device Status';
+    private const string HEADER_BUSY = 'Device Status  polling...';
+    private const string SEPARATOR_TEXT = '----------------------------------------------------------------';
+    private const string FOOTER_HINT = '[Esc] back';
+    private const string NO_DATA_TEXT = 'No data';
+    private const string UNREACHABLE_TEXT = 'Unreachable';
+
+    private readonly TextWidget $header;
+    private readonly TextWidget $body;
+    private readonly ContainerWidget $container;
+
+    public function __construct()
+    {
+        $this->header = new TextWidget(self::HEADER_BASE);
+        $this->body = new TextWidget(self::NO_DATA_TEXT);
+
+        $this->container = new ContainerWidget();
+        $this->container->expandVertically(true);
+        $this->container->add($this->header);
+        $this->container->add(new TextWidget(self::SEPARATOR_TEXT));
+        $this->container->add($this->body);
+        $this->container->add(new TextWidget(self::FOOTER_HINT));
+    }
+
+    public function widget(): AbstractWidget
+    {
+        return $this->container;
+    }
+
+    public function update(?StatsSnapshot $snapshot, bool $busy): void
+    {
+        $this->header->setText($busy ? self::HEADER_BUSY : self::HEADER_BASE);
+
+        if (null === $snapshot) {
+            $this->body->setText(self::NO_DATA_TEXT);
+
+            return;
+        }
+
+        if (!$snapshot->reachable) {
+            $this->body->setText(self::UNREACHABLE_TEXT);
+
+            return;
+        }
+
+        $this->body->setText(StatsFormatter::format($snapshot));
+    }
+
+    public function headerText(): string
+    {
+        return $this->header->getText();
+    }
+
+    public function bodyText(): string
+    {
+        return $this->body->getText();
+    }
+}

--- a/src/Tui/DeviceStatus/StatsFormatter.php
+++ b/src/Tui/DeviceStatus/StatsFormatter.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceStatus;
+
+final class StatsFormatter
+{
+    private const string MISSING_VALUE = 'n/a';
+
+    public static function format(StatsSnapshot $snapshot): string
+    {
+        $lines = [
+            'Uptime:    '.self::formatUptime($snapshot->uptimeSeconds),
+            'Free heap: '.self::formatBytes($snapshot->freeHeapBytes),
+            'IP:        '.self::formatString($snapshot->ipAddress),
+            'Firmware:  '.self::formatString($snapshot->firmwareVersion),
+            '',
+            '[Settings]',
+            'Brightness:       '.self::formatInt($snapshot->brightness),
+            'Auto rotate:      '.self::formatBool($snapshot->autoRotate),
+            'Default duration: '.self::formatDuration($snapshot->defaultDurationSeconds),
+        ];
+
+        return implode("\n", $lines);
+    }
+
+    public static function formatUptime(?int $seconds): string
+    {
+        if (null === $seconds || $seconds < 0) {
+            return self::MISSING_VALUE;
+        }
+
+        $days = intdiv($seconds, 86_400);
+        $hours = intdiv($seconds % 86_400, 3_600);
+        $minutes = intdiv($seconds % 3_600, 60);
+        $secondsRemainder = $seconds % 60;
+
+        if ($days > 0) {
+            return \sprintf('%dd %02dh %02dm %02ds', $days, $hours, $minutes, $secondsRemainder);
+        }
+
+        if ($hours > 0) {
+            return \sprintf('%dh %02dm %02ds', $hours, $minutes, $secondsRemainder);
+        }
+
+        if ($minutes > 0) {
+            return \sprintf('%dm %02ds', $minutes, $secondsRemainder);
+        }
+
+        return \sprintf('%ds', $secondsRemainder);
+    }
+
+    public static function formatBytes(?int $bytes): string
+    {
+        if (null === $bytes || $bytes < 0) {
+            return self::MISSING_VALUE;
+        }
+
+        if ($bytes < 1024) {
+            return $bytes.' B';
+        }
+
+        return \sprintf('%.1f KB', $bytes / 1024);
+    }
+
+    public static function formatBool(?bool $value): string
+    {
+        return match ($value) {
+            true => 'enabled',
+            false => 'disabled',
+            null => self::MISSING_VALUE,
+        };
+    }
+
+    private static function formatString(?string $value): string
+    {
+        return (null === $value || '' === $value) ? self::MISSING_VALUE : $value;
+    }
+
+    private static function formatInt(?int $value): string
+    {
+        return null === $value ? self::MISSING_VALUE : (string) $value;
+    }
+
+    private static function formatDuration(?int $seconds): string
+    {
+        return null === $seconds ? self::MISSING_VALUE : $seconds.'s';
+    }
+}

--- a/src/Tui/DeviceStatus/StatsHttpClient.php
+++ b/src/Tui/DeviceStatus/StatsHttpClient.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceStatus;
+
+final class StatsHttpClient implements StatsTransport
+{
+    public function __construct(
+        private readonly float $timeoutSeconds = 0.5,
+    ) {
+    }
+
+    public function fetch(?string $baseUrl): StatsSnapshot
+    {
+        if (null === $baseUrl || '' === $baseUrl) {
+            return StatsSnapshot::unreachable('no base URL configured');
+        }
+
+        $statsUrl = rtrim($baseUrl, '/').'/api/stats';
+
+        $streamContext = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'timeout' => $this->timeoutSeconds,
+                'ignore_errors' => true,
+                'header' => "Accept: application/json\r\n",
+            ],
+        ]);
+
+        // file_get_contents emits a PHP warning on connection failure; we
+        // swallow it here because we already detect the failure via false.
+        set_error_handler(static fn (): bool => true);
+        try {
+            $response = file_get_contents($statsUrl, false, $streamContext);
+        } finally {
+            restore_error_handler();
+        }
+
+        if (false === $response) {
+            return StatsSnapshot::unreachable('connection failed');
+        }
+
+        $decoded = json_decode($response, true);
+        if (!\is_array($decoded)) {
+            return StatsSnapshot::unreachable('invalid response');
+        }
+
+        /** @var array<string, mixed> $payload */
+        $payload = $decoded;
+
+        return StatsSnapshot::fromStatsPayload($payload);
+    }
+}

--- a/src/Tui/DeviceStatus/StatsPoller.php
+++ b/src/Tui/DeviceStatus/StatsPoller.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceStatus;
+
+final class StatsPoller
+{
+    private ?StatsSnapshot $latestSnapshot = null;
+    private float $secondsSinceLastPoll = 0.0;
+
+    public function __construct(
+        private readonly StatsTransport $httpClient,
+        private readonly ?string $baseUrl,
+        private readonly float $pollIntervalSeconds = 2.0,
+    ) {
+    }
+
+    public function poll(): StatsSnapshot
+    {
+        $snapshot = $this->httpClient->fetch($this->baseUrl);
+        $this->latestSnapshot = $snapshot;
+        $this->secondsSinceLastPoll = 0.0;
+
+        return $snapshot;
+    }
+
+    public function pollIfDue(float $deltaSeconds): bool
+    {
+        $clampedDelta = max(0.0, $deltaSeconds);
+        $this->secondsSinceLastPoll += $clampedDelta;
+
+        if ($this->secondsSinceLastPoll < $this->pollIntervalSeconds) {
+            return false;
+        }
+
+        $this->poll();
+
+        return true;
+    }
+
+    public function getLatestSnapshot(): ?StatsSnapshot
+    {
+        return $this->latestSnapshot;
+    }
+}

--- a/src/Tui/DeviceStatus/StatsSnapshot.php
+++ b/src/Tui/DeviceStatus/StatsSnapshot.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceStatus;
+
+final readonly class StatsSnapshot
+{
+    public function __construct(
+        public bool $reachable,
+        public ?string $errorMessage = null,
+        public ?int $uptimeSeconds = null,
+        public ?int $freeHeapBytes = null,
+        public ?string $firmwareVersion = null,
+        public ?string $ipAddress = null,
+        public ?int $brightness = null,
+        public ?bool $autoRotate = null,
+        public ?int $defaultDurationSeconds = null,
+    ) {
+    }
+
+    public static function unreachable(string $errorMessage): self
+    {
+        return new self(reachable: false, errorMessage: $errorMessage);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public static function fromStatsPayload(array $payload): self
+    {
+        $wifi = self::nestedArray($payload, 'wifi');
+        $apps = self::nestedArray($payload, 'apps');
+
+        return new self(
+            reachable: true,
+            uptimeSeconds: self::intOrNull($payload, 'uptime'),
+            freeHeapBytes: self::intOrNull($payload, 'freeHeap'),
+            firmwareVersion: self::stringOrNull($payload, 'version'),
+            ipAddress: self::stringOrNull($wifi, 'ip'),
+            brightness: self::intOrNull($payload, 'brightness'),
+            autoRotate: self::boolOrNull($apps, 'rotationEnabled'),
+            defaultDurationSeconds: self::intOrNull($payload, 'defaultDuration'),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private static function nestedArray(array $payload, string $key): array
+    {
+        if (!isset($payload[$key]) || !\is_array($payload[$key])) {
+            return [];
+        }
+
+        /** @var array<string, mixed> $nested */
+        $nested = $payload[$key];
+
+        return $nested;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function intOrNull(array $payload, string $key): ?int
+    {
+        return isset($payload[$key]) && \is_int($payload[$key]) ? $payload[$key] : null;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function stringOrNull(array $payload, string $key): ?string
+    {
+        return isset($payload[$key]) && \is_string($payload[$key]) ? $payload[$key] : null;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function boolOrNull(array $payload, string $key): ?bool
+    {
+        return isset($payload[$key]) && \is_bool($payload[$key]) ? $payload[$key] : null;
+    }
+}

--- a/src/Tui/DeviceStatus/StatsTransport.php
+++ b/src/Tui/DeviceStatus/StatsTransport.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceStatus;
+
+interface StatsTransport
+{
+    public function fetch(?string $baseUrl): StatsSnapshot;
+}

--- a/tests/Command/TuiCommandWiringTest.php
+++ b/tests/Command/TuiCommandWiringTest.php
@@ -8,6 +8,8 @@ use App\Command\TuiCommand;
 use App\Config\PixelCastConfigLoader;
 use App\Config\PixelCastConfigWriter;
 use App\Tui\Configuration\ConfigurationFieldValidator;
+use App\Tui\DeviceStatus\StatsHttpClient;
+use App\Tui\DeviceStatus\StatsTransport;
 use App\Tui\ResetSim\ResetSimulatorAction;
 use App\Tui\Scenarios\ScenarioCatalog;
 use App\Tui\Scenarios\ScenarioDispatcher;
@@ -106,5 +108,14 @@ final class TuiCommandWiringTest extends KernelTestCase
         $validator = self::getContainer()->get(ConfigurationFieldValidator::class);
 
         self::assertInstanceOf(ConfigurationFieldValidator::class, $validator);
+    }
+
+    public function testStatsTransportResolvesToStatsHttpClient(): void
+    {
+        self::bootKernel();
+
+        $transport = self::getContainer()->get(StatsTransport::class);
+
+        self::assertInstanceOf(StatsHttpClient::class, $transport);
     }
 }

--- a/tests/Tui/DeviceStatus/Panel/DeviceStatusPanelTest.php
+++ b/tests/Tui/DeviceStatus/Panel/DeviceStatusPanelTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\DeviceStatus\Panel;
+
+use App\Tui\DeviceStatus\Panel\DeviceStatusPanel;
+use App\Tui\DeviceStatus\StatsSnapshot;
+use PHPUnit\Framework\TestCase;
+
+final class DeviceStatusPanelTest extends TestCase
+{
+    public function testInitialBodyShowsNoData(): void
+    {
+        $panel = new DeviceStatusPanel();
+
+        self::assertSame('Device Status', $panel->headerText());
+        self::assertSame('No data', $panel->bodyText());
+    }
+
+    public function testUpdateWithNullSnapshotShowsNoData(): void
+    {
+        $panel = new DeviceStatusPanel();
+        $panel->update(null, busy: false);
+
+        self::assertSame('Device Status', $panel->headerText());
+        self::assertSame('No data', $panel->bodyText());
+    }
+
+    public function testUpdateWithUnreachableSnapshotShowsUnreachable(): void
+    {
+        $panel = new DeviceStatusPanel();
+        $panel->update(StatsSnapshot::unreachable('connection failed'), busy: false);
+
+        self::assertSame('Device Status', $panel->headerText());
+        self::assertSame('Unreachable', $panel->bodyText());
+    }
+
+    public function testUpdateWithBusyTrueShowsPollingHeader(): void
+    {
+        $panel = new DeviceStatusPanel();
+        $panel->update(StatsSnapshot::unreachable('timeout'), busy: true);
+
+        self::assertSame('Device Status  polling...', $panel->headerText());
+    }
+
+    public function testUpdateWithReachableSnapshotRendersFields(): void
+    {
+        $panel = new DeviceStatusPanel();
+        $snapshot = StatsSnapshot::fromStatsPayload([
+            'version' => '0.1.0-dev',
+            'uptime' => 3661,
+            'freeHeap' => 187_392,
+            'brightness' => 128,
+            'wifi' => ['ip' => '192.168.1.42'],
+            'apps' => ['rotationEnabled' => true],
+        ]);
+
+        $panel->update($snapshot, busy: false);
+
+        $body = $panel->bodyText();
+        self::assertStringContainsString('Uptime:', $body);
+        self::assertStringContainsString('Free heap:', $body);
+        self::assertStringContainsString('IP:        192.168.1.42', $body);
+        self::assertStringContainsString('Firmware:  0.1.0-dev', $body);
+        self::assertStringContainsString('Brightness:       128', $body);
+    }
+}

--- a/tests/Tui/DeviceStatus/StatsFormatterTest.php
+++ b/tests/Tui/DeviceStatus/StatsFormatterTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\DeviceStatus;
+
+use App\Tui\DeviceStatus\StatsFormatter;
+use App\Tui\DeviceStatus\StatsSnapshot;
+use PHPUnit\Framework\TestCase;
+
+final class StatsFormatterTest extends TestCase
+{
+    public function testFormatUptimeBelowOneMinuteShowsSeconds(): void
+    {
+        self::assertSame('0s', StatsFormatter::formatUptime(0));
+        self::assertSame('45s', StatsFormatter::formatUptime(45));
+    }
+
+    public function testFormatUptimeBelowOneHourShowsMinutes(): void
+    {
+        self::assertSame('1m 05s', StatsFormatter::formatUptime(65));
+        self::assertSame('59m 59s', StatsFormatter::formatUptime(3599));
+    }
+
+    public function testFormatUptimeBelowOneDayShowsHours(): void
+    {
+        self::assertSame('1h 01m 01s', StatsFormatter::formatUptime(3661));
+        self::assertSame('23h 59m 59s', StatsFormatter::formatUptime(86_399));
+    }
+
+    public function testFormatUptimeWithDaysShowsDays(): void
+    {
+        self::assertSame('1d 00h 00m 00s', StatsFormatter::formatUptime(86_400));
+        self::assertSame('2d 03h 04m 05s', StatsFormatter::formatUptime(2 * 86_400 + 3 * 3600 + 4 * 60 + 5));
+    }
+
+    public function testFormatUptimeWithNullOrNegativeReturnsNotAvailable(): void
+    {
+        self::assertSame('n/a', StatsFormatter::formatUptime(null));
+        self::assertSame('n/a', StatsFormatter::formatUptime(-1));
+    }
+
+    public function testFormatBytesBelowOneKiloShowsBytes(): void
+    {
+        self::assertSame('0 B', StatsFormatter::formatBytes(0));
+        self::assertSame('1023 B', StatsFormatter::formatBytes(1023));
+    }
+
+    public function testFormatBytesAboveOneKiloShowsKilobytesWithOneDecimal(): void
+    {
+        self::assertSame('1.0 KB', StatsFormatter::formatBytes(1024));
+        self::assertSame('183.0 KB', StatsFormatter::formatBytes(187_392));
+    }
+
+    public function testFormatBytesWithNullReturnsNotAvailable(): void
+    {
+        self::assertSame('n/a', StatsFormatter::formatBytes(null));
+    }
+
+    public function testFormatBoolHandlesAllThreeStates(): void
+    {
+        self::assertSame('enabled', StatsFormatter::formatBool(true));
+        self::assertSame('disabled', StatsFormatter::formatBool(false));
+        self::assertSame('n/a', StatsFormatter::formatBool(null));
+    }
+
+    public function testFormatReachableSnapshotRendersAllFields(): void
+    {
+        $snapshot = StatsSnapshot::fromStatsPayload([
+            'version' => '0.1.0-dev',
+            'uptime' => 3661,
+            'freeHeap' => 187_392,
+            'brightness' => 128,
+            'wifi' => ['ip' => '192.168.1.42'],
+            'apps' => ['rotationEnabled' => true],
+        ]);
+
+        $output = StatsFormatter::format($snapshot);
+
+        self::assertStringContainsString('Uptime:    1h 01m 01s', $output);
+        self::assertStringContainsString('Free heap: 183.0 KB', $output);
+        self::assertStringContainsString('IP:        192.168.1.42', $output);
+        self::assertStringContainsString('Firmware:  0.1.0-dev', $output);
+        self::assertStringContainsString('Brightness:       128', $output);
+        self::assertStringContainsString('Auto rotate:      enabled', $output);
+        self::assertStringContainsString('Default duration: n/a', $output);
+    }
+
+    public function testFormatSnapshotWithMissingFieldsRendersNotAvailable(): void
+    {
+        $output = StatsFormatter::format(StatsSnapshot::fromStatsPayload([]));
+
+        self::assertStringContainsString('Uptime:    n/a', $output);
+        self::assertStringContainsString('Free heap: n/a', $output);
+        self::assertStringContainsString('IP:        n/a', $output);
+        self::assertStringContainsString('Firmware:  n/a', $output);
+        self::assertStringContainsString('Brightness:       n/a', $output);
+        self::assertStringContainsString('Auto rotate:      n/a', $output);
+        self::assertStringContainsString('Default duration: n/a', $output);
+    }
+}

--- a/tests/Tui/DeviceStatus/StatsPollerTest.php
+++ b/tests/Tui/DeviceStatus/StatsPollerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\DeviceStatus;
+
+use App\Tui\DeviceStatus\StatsPoller;
+use App\Tui\DeviceStatus\StatsSnapshot;
+use App\Tui\DeviceStatus\StatsTransport;
+use PHPUnit\Framework\TestCase;
+
+final class StatsPollerTest extends TestCase
+{
+    public function testPollIfDueDoesNothingBeforeIntervalElapsed(): void
+    {
+        $stubClient = new CountingStatsHttpClientStub();
+        $poller = new StatsPoller($stubClient, 'http://example.invalid', pollIntervalSeconds: 2.0);
+
+        $firstResult = $poller->pollIfDue(0.8);
+        $secondResult = $poller->pollIfDue(0.8);
+
+        self::assertFalse($firstResult);
+        self::assertFalse($secondResult);
+        self::assertSame(0, $stubClient->fetchCount);
+        self::assertNull($poller->getLatestSnapshot());
+    }
+
+    public function testPollIfDueFiresWhenAccumulatedDeltaReachesInterval(): void
+    {
+        $stubClient = new CountingStatsHttpClientStub();
+        $poller = new StatsPoller($stubClient, 'http://example.invalid', pollIntervalSeconds: 2.0);
+
+        $beforeInterval = $poller->pollIfDue(1.2);
+        $atInterval = $poller->pollIfDue(1.0);
+
+        self::assertFalse($beforeInterval);
+        self::assertTrue($atInterval);
+        self::assertSame(1, $stubClient->fetchCount);
+        $latestSnapshot = $poller->getLatestSnapshot();
+        self::assertNotNull($latestSnapshot);
+        self::assertTrue($latestSnapshot->reachable);
+    }
+
+    public function testPollAlwaysFiresAndResetsAccumulator(): void
+    {
+        $stubClient = new CountingStatsHttpClientStub();
+        $poller = new StatsPoller($stubClient, 'http://example.invalid', pollIntervalSeconds: 2.0);
+
+        $poller->pollIfDue(1.0);
+        $snapshot = $poller->poll();
+
+        self::assertSame(1, $stubClient->fetchCount);
+        self::assertSame($snapshot, $poller->getLatestSnapshot());
+
+        $immediatelyAfter = $poller->pollIfDue(1.0);
+        self::assertFalse($immediatelyAfter);
+        self::assertSame(1, $stubClient->fetchCount);
+
+        $afterFullInterval = $poller->pollIfDue(1.0);
+        self::assertTrue($afterFullInterval);
+        self::assertSame(2, $stubClient->fetchCount);
+    }
+
+    public function testNegativeDeltaIsClampedToZero(): void
+    {
+        $stubClient = new CountingStatsHttpClientStub();
+        $poller = new StatsPoller($stubClient, 'http://example.invalid', pollIntervalSeconds: 2.0);
+
+        $poller->pollIfDue(-100.0);
+        $poller->pollIfDue(-100.0);
+
+        self::assertSame(0, $stubClient->fetchCount);
+        self::assertNull($poller->getLatestSnapshot());
+
+        $fired = $poller->pollIfDue(2.0);
+        self::assertTrue($fired);
+        self::assertSame(1, $stubClient->fetchCount);
+    }
+}
+
+final class CountingStatsHttpClientStub implements StatsTransport
+{
+    public int $fetchCount = 0;
+
+    public function fetch(?string $baseUrl): StatsSnapshot
+    {
+        ++$this->fetchCount;
+
+        return StatsSnapshot::fromStatsPayload([
+            'version' => '0.1.0-dev',
+            'uptime' => 42,
+            'freeHeap' => 1024,
+            'wifi' => ['ip' => '10.0.0.1'],
+            'apps' => ['rotationEnabled' => false],
+            'brightness' => 100,
+        ]);
+    }
+}

--- a/tests/Tui/DeviceStatus/StatsSnapshotTest.php
+++ b/tests/Tui/DeviceStatus/StatsSnapshotTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\DeviceStatus;
+
+use App\Tui\DeviceStatus\StatsSnapshot;
+use PHPUnit\Framework\TestCase;
+
+final class StatsSnapshotTest extends TestCase
+{
+    public function testUnreachableFactoryProducesUnreachableSnapshot(): void
+    {
+        $snapshot = StatsSnapshot::unreachable('connection failed');
+
+        self::assertFalse($snapshot->reachable);
+        self::assertSame('connection failed', $snapshot->errorMessage);
+        self::assertNull($snapshot->uptimeSeconds);
+        self::assertNull($snapshot->freeHeapBytes);
+        self::assertNull($snapshot->firmwareVersion);
+        self::assertNull($snapshot->ipAddress);
+        self::assertNull($snapshot->brightness);
+        self::assertNull($snapshot->autoRotate);
+        self::assertNull($snapshot->defaultDurationSeconds);
+    }
+
+    public function testFromStatsPayloadMapsRepresentativePayload(): void
+    {
+        $payload = [
+            'version' => '0.1.0-dev',
+            'uptime' => 3661,
+            'freeHeap' => 188_416,
+            'maxAllocHeap' => 65_536,
+            'brightness' => 128,
+            'wifi' => [
+                'ssid' => 'home-network',
+                'rssi' => -55,
+                'ip' => '192.168.1.42',
+            ],
+            'apps' => [
+                'count' => 4,
+                'current' => 'weather',
+                'rotationEnabled' => true,
+            ],
+        ];
+
+        $snapshot = StatsSnapshot::fromStatsPayload($payload);
+
+        self::assertTrue($snapshot->reachable);
+        self::assertNull($snapshot->errorMessage);
+        self::assertSame(3661, $snapshot->uptimeSeconds);
+        self::assertSame(188_416, $snapshot->freeHeapBytes);
+        self::assertSame('0.1.0-dev', $snapshot->firmwareVersion);
+        self::assertSame('192.168.1.42', $snapshot->ipAddress);
+        self::assertSame(128, $snapshot->brightness);
+        self::assertTrue($snapshot->autoRotate);
+        self::assertNull($snapshot->defaultDurationSeconds);
+    }
+
+    public function testFromStatsPayloadReadsOptionalDefaultDurationWhenPresent(): void
+    {
+        $snapshot = StatsSnapshot::fromStatsPayload([
+            'version' => '0.2.0',
+            'defaultDuration' => 7,
+        ]);
+
+        self::assertTrue($snapshot->reachable);
+        self::assertSame(7, $snapshot->defaultDurationSeconds);
+    }
+
+    public function testFromStatsPayloadHandlesMissingNestedKeys(): void
+    {
+        $snapshot = StatsSnapshot::fromStatsPayload([]);
+
+        self::assertTrue($snapshot->reachable);
+        self::assertNull($snapshot->uptimeSeconds);
+        self::assertNull($snapshot->ipAddress);
+        self::assertNull($snapshot->autoRotate);
+    }
+
+    public function testFromStatsPayloadIgnoresWrongTypes(): void
+    {
+        $snapshot = StatsSnapshot::fromStatsPayload([
+            'uptime' => '123',
+            'freeHeap' => 1024,
+            'wifi' => 'not-an-array',
+            'apps' => ['rotationEnabled' => 'yes'],
+        ]);
+
+        self::assertTrue($snapshot->reachable);
+        self::assertNull($snapshot->uptimeSeconds);
+        self::assertSame(1024, $snapshot->freeHeapBytes);
+        self::assertNull($snapshot->ipAddress);
+        self::assertNull($snapshot->autoRotate);
+    }
+}


### PR DESCRIPTION
## Summary

Wires the `[3] Device Status` prod-mode menu entry to a new panel that polls `GET /api/stats` every 2 s (HTTP timeout 0.5 s) and renders uptime, free heap, IP, firmware version, and a settings snapshot (brightness, autoRotate, defaultDuration). Unreachable device displays "Unreachable" without freezing the TUI. Mirrors the existing inspector pattern (transport, snapshot, poller, panel).

Closes #33