### PR TITLE
fix: start simulator HTTP server via compose override

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -21,6 +21,7 @@ services:
       php:
         condition: service_started
     working_dir: /app
+    entrypoint: []
     command: php -S 0.0.0.0:8080 -t public/
     volumes:
       - .:/app


### PR DESCRIPTION
## Summary

The `simulator` dev container was inheriting `ENTRYPOINT ["sleep", "infinity"]` from the `php_dev` Dockerfile stage, so its `command: php -S 0.0.0.0:8080 -t public/` was never executed (it became extra args to `sleep`, which ignores them). Result: the container appeared healthy but nothing listened on port 8080, the TUI's reachability probe failed with TCP "connection refused", and the status bar showed `UNREACHABLE`.

This change adds `entrypoint: []` to the `simulator` service override so the compose `command:` is the actual process. The `php` service keeps the inherited `sleep infinity` (still needed there for `docker compose exec`).

## Verification

- `docker compose ps` now shows the simulator running `php -S 0.0.0.0:8080…` instead of `sleep infinity`.
- TCP probe from the `php` container to `simulator:8080` returns reachable.
- `GET /__inspect` on `http://localhost:8088` responds with the simulator state.