### PR TITLE
feat(domain): add AppDomain enum and DeviceStateSource contract

### DIFF
--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -9,6 +9,13 @@ use App\Config\PixelCastConfigWriter;
 use App\Tui\Configuration\ConfigurationFieldValidator;
 use App\Tui\Configuration\Panel\ConfigurationPanel;
 use App\Tui\Configuration\SaveOutcome;
+use App\Tui\DeviceState\Prod\Http\HttpJsonFetcher;
+use App\Tui\DeviceState\Prod\ProdDeviceStateSource;
+use App\Tui\DeviceState\Prod\Transport\IconsTransport;
+use App\Tui\DeviceState\Prod\Transport\NotificationsTransport;
+use App\Tui\DeviceState\Prod\Transport\SettingsTransport;
+use App\Tui\DeviceState\Prod\Transport\TrackersTransport;
+use App\Tui\DeviceState\Prod\Transport\WeatherTransport;
 use App\Tui\DeviceStatus\Panel\DeviceStatusPanel;
 use App\Tui\DeviceStatus\StatsPoller;
 use App\Tui\DeviceStatus\StatsTransport;
@@ -82,6 +89,7 @@ final class TuiCommand extends Command
         $inspectorPoller = null;
         $stateInspectorPanel = null;
         $requestLogPanel = null;
+        $prodDeviceStateSource = null;
 
         if (TuiMode::Dev === $mode) {
             $inspectorPoller = new InspectorPoller(
@@ -124,6 +132,16 @@ final class TuiCommand extends Command
             $statsPoller = new StatsPoller($this->statsHttpClient, $effectiveDeviceUrl);
             $deviceStatusPanel = new DeviceStatusPanel();
             $deviceStatusPanel->update($statsPoller->poll(), busy: false);
+
+            $httpJsonFetcher = new HttpJsonFetcher();
+            $prodDeviceStateSource = new ProdDeviceStateSource(
+                new WeatherTransport($httpJsonFetcher),
+                new TrackersTransport($httpJsonFetcher),
+                new NotificationsTransport($httpJsonFetcher),
+                new IconsTransport($httpJsonFetcher),
+                new SettingsTransport($httpJsonFetcher),
+                $effectiveDeviceUrl,
+            );
         }
 
         $viewContainer = new ContainerWidget();
@@ -165,6 +183,10 @@ final class TuiCommand extends Command
                 $statsPoller,
                 $deviceStatusPanel,
             ));
+        }
+
+        if (null !== $prodDeviceStateSource) {
+            $tui->addListener($this->buildProdDeviceStateTickListener($prodDeviceStateSource));
         }
 
         if (null !== $inspectorPoller) {
@@ -383,6 +405,18 @@ final class TuiCommand extends Command
             $event->setBusy(true);
             $deviceStatusPanel->update($statsPoller->getLatestSnapshot(), busy: false);
             $tui->requestRender();
+        };
+    }
+
+    private function buildProdDeviceStateTickListener(
+        ProdDeviceStateSource $prodDeviceStateSource,
+    ): callable {
+        return static function (TickEvent $event) use ($prodDeviceStateSource): void {
+            if (!$prodDeviceStateSource->refresh($event->getDeltaTime())) {
+                return;
+            }
+
+            $event->setBusy(true);
         };
     }
 

--- a/src/Domain/AppDomain.php
+++ b/src/Domain/AppDomain.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain;
+
+enum AppDomain: string
+{
+    case Weather = 'weather';
+    case Trackers = 'trackers';
+    case Notifications = 'notifications';
+    case CustomApps = 'customApps';
+    case Indicators = 'indicators';
+    case Icons = 'icons';
+}

--- a/src/Tui/DeviceState/Dev/DevDeviceStateSource.php
+++ b/src/Tui/DeviceState/Dev/DevDeviceStateSource.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceState\Dev;
+
+use App\Domain\AppDomain;
+use App\Tui\DeviceState\DeviceDomainState;
+use App\Tui\DeviceState\DeviceStateSource;
+use App\Tui\Inspector\InspectorPoller;
+
+final class DevDeviceStateSource implements DeviceStateSource
+{
+    public function __construct(private readonly InspectorPoller $poller)
+    {
+    }
+
+    public function refresh(float $deltaSeconds): bool
+    {
+        return $this->poller->pollIfDue($deltaSeconds);
+    }
+
+    public function snapshot(): array
+    {
+        $result = [];
+        foreach (AppDomain::cases() as $domain) {
+            $result[$domain->value] = $this->getDomainState($domain);
+        }
+
+        return $result;
+    }
+
+    public function getDomainState(AppDomain $domain): DeviceDomainState
+    {
+        $snapshot = $this->poller->getLatestSnapshot();
+        if (null === $snapshot || false === $snapshot->reachable || null === $snapshot->state) {
+            return new DeviceDomainState(false, null);
+        }
+
+        $payload = $snapshot->state[$domain->value] ?? null;
+        if (null === $payload) {
+            return new DeviceDomainState(false, null);
+        }
+
+        $hasData = match ($domain) {
+            AppDomain::Weather => $this->hasWeatherData($payload),
+            AppDomain::Trackers => $this->hasNonEmptyCollection($payload, 'trackers'),
+            AppDomain::Notifications => $this->hasNonEmptyCollection($payload, 'queue'),
+            AppDomain::CustomApps => $this->hasNonEmptyCollection($payload, 'apps'),
+            AppDomain::Indicators => $this->hasAnyIndicatorSlot($payload),
+            AppDomain::Icons => $this->hasNonEmptyCollection($payload, 'icons'),
+        };
+
+        return new DeviceDomainState($hasData, $payload);
+    }
+
+    private function hasWeatherData(mixed $payload): bool
+    {
+        return \is_array($payload) && null !== ($payload['current'] ?? null);
+    }
+
+    private function hasNonEmptyCollection(mixed $payload, string $collectionKey): bool
+    {
+        if (!\is_array($payload)) {
+            return false;
+        }
+        $collection = $payload[$collectionKey] ?? null;
+
+        return \is_array($collection) && [] !== $collection;
+    }
+
+    private function hasAnyIndicatorSlot(mixed $payload): bool
+    {
+        if (!\is_array($payload)) {
+            return false;
+        }
+        foreach (['slot1', 'slot2', 'slot3'] as $slotKey) {
+            if (null !== ($payload[$slotKey] ?? null)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Tui/DeviceState/DeviceDomainState.php
+++ b/src/Tui/DeviceState/DeviceDomainState.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceState;
+
+final readonly class DeviceDomainState
+{
+    public function __construct(
+        public bool $hasData,
+        public mixed $payload,
+    ) {
+    }
+}

--- a/src/Tui/DeviceState/DeviceStateSource.php
+++ b/src/Tui/DeviceState/DeviceStateSource.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceState;
+
+use App\Domain\AppDomain;
+
+interface DeviceStateSource
+{
+    public function getDomainState(AppDomain $domain): DeviceDomainState;
+
+    /**
+     * @return array<string, DeviceDomainState> keyed by AppDomain::value
+     */
+    public function snapshot(): array;
+
+    public function refresh(float $deltaSeconds): bool;
+}

--- a/src/Tui/DeviceState/Prod/Http/HttpJsonFetcher.php
+++ b/src/Tui/DeviceState/Prod/Http/HttpJsonFetcher.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceState\Prod\Http;
+
+class HttpJsonFetcher
+{
+    public function __construct(
+        private readonly float $timeoutSeconds = 0.5,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>|null null when the endpoint is unreachable or the response is not a JSON object
+     */
+    public function fetchJson(string $url): ?array
+    {
+        $streamContext = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'timeout' => $this->timeoutSeconds,
+                'ignore_errors' => true,
+                'header' => "Accept: application/json\r\n",
+            ],
+        ]);
+
+        // file_get_contents emits a PHP warning on connection failure; we
+        // swallow it here because we already detect the failure via false.
+        set_error_handler(static fn (): bool => true);
+        try {
+            $response = file_get_contents($url, false, $streamContext);
+        } finally {
+            restore_error_handler();
+        }
+
+        if (false === $response) {
+            return null;
+        }
+
+        $decoded = json_decode($response, true);
+        if (!\is_array($decoded)) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+}

--- a/src/Tui/DeviceState/Prod/ProdDeviceStateSource.php
+++ b/src/Tui/DeviceState/Prod/ProdDeviceStateSource.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceState\Prod;
+
+use App\Domain\AppDomain;
+use App\Tui\DeviceState\DeviceDomainState;
+use App\Tui\DeviceState\DeviceStateSource;
+use App\Tui\DeviceState\Prod\Transport\IconsTransport;
+use App\Tui\DeviceState\Prod\Transport\NotificationsTransport;
+use App\Tui\DeviceState\Prod\Transport\SettingsTransport;
+use App\Tui\DeviceState\Prod\Transport\TrackersTransport;
+use App\Tui\DeviceState\Prod\Transport\WeatherTransport;
+
+final class ProdDeviceStateSource implements DeviceStateSource
+{
+    /** @var array<string, DeviceDomainState> keyed by AppDomain::value */
+    private array $latestDomainStates;
+
+    /** @var array<string, mixed>|null */
+    private ?array $latestSettings = null;
+
+    private float $accumulatedSeconds = 0.0;
+
+    public function __construct(
+        private readonly WeatherTransport $weatherTransport,
+        private readonly TrackersTransport $trackersTransport,
+        private readonly NotificationsTransport $notificationsTransport,
+        private readonly IconsTransport $iconsTransport,
+        private readonly SettingsTransport $settingsTransport,
+        private readonly ?string $baseUrl,
+        private readonly float $pollIntervalSeconds = 2.0,
+    ) {
+        $this->latestDomainStates = [];
+        foreach (AppDomain::cases() as $domain) {
+            $this->latestDomainStates[$domain->value] = new DeviceDomainState(false, null);
+        }
+    }
+
+    public function getDomainState(AppDomain $domain): DeviceDomainState
+    {
+        return $this->latestDomainStates[$domain->value];
+    }
+
+    public function snapshot(): array
+    {
+        return $this->latestDomainStates;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function latestSettings(): ?array
+    {
+        return $this->latestSettings;
+    }
+
+    public function refresh(float $deltaSeconds): bool
+    {
+        $clampedDelta = max(0.0, $deltaSeconds);
+        $this->accumulatedSeconds += $clampedDelta;
+        if ($this->accumulatedSeconds < $this->pollIntervalSeconds) {
+            return false;
+        }
+        $this->accumulatedSeconds = 0.0;
+        $this->pollAllDomains();
+
+        return true;
+    }
+
+    private function pollAllDomains(): void
+    {
+        $weatherPayload = $this->weatherTransport->fetch($this->baseUrl);
+        $trackersPayload = $this->trackersTransport->fetch($this->baseUrl);
+        $notificationsPayload = $this->notificationsTransport->fetch($this->baseUrl);
+        $iconsPayload = $this->iconsTransport->fetch($this->baseUrl);
+        $settingsPayload = $this->settingsTransport->fetch($this->baseUrl);
+
+        $emptyDomainState = new DeviceDomainState(false, null);
+
+        $this->latestDomainStates = [
+            AppDomain::Weather->value => new DeviceDomainState(
+                $this->hasWeatherData($weatherPayload),
+                $weatherPayload,
+            ),
+            AppDomain::Trackers->value => new DeviceDomainState(
+                $this->hasNonEmptyCollection($trackersPayload, 'trackers'),
+                $trackersPayload,
+            ),
+            AppDomain::Notifications->value => new DeviceDomainState(
+                $this->hasNonEmptyCollection($notificationsPayload, 'notifications'),
+                $notificationsPayload,
+            ),
+            AppDomain::CustomApps->value => $emptyDomainState,
+            AppDomain::Indicators->value => $emptyDomainState,
+            AppDomain::Icons->value => new DeviceDomainState(
+                $this->hasNonEmptyCollection($iconsPayload, 'icons'),
+                $iconsPayload,
+            ),
+        ];
+        $this->latestSettings = $settingsPayload;
+    }
+
+    /**
+     * @param array<string, mixed>|null $payload
+     */
+    private function hasWeatherData(?array $payload): bool
+    {
+        return null !== $payload && null !== ($payload['current'] ?? null);
+    }
+
+    /**
+     * @param array<string, mixed>|null $payload
+     */
+    private function hasNonEmptyCollection(?array $payload, string $collectionKey): bool
+    {
+        if (null === $payload) {
+            return false;
+        }
+        $collection = $payload[$collectionKey] ?? null;
+
+        return \is_array($collection) && [] !== $collection;
+    }
+}

--- a/src/Tui/DeviceState/Prod/Transport/IconsTransport.php
+++ b/src/Tui/DeviceState/Prod/Transport/IconsTransport.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceState\Prod\Transport;
+
+use App\Tui\DeviceState\Prod\Http\HttpJsonFetcher;
+
+final class IconsTransport
+{
+    public function __construct(private readonly HttpJsonFetcher $fetcher)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function fetch(?string $baseUrl): ?array
+    {
+        if (null === $baseUrl || '' === $baseUrl) {
+            return null;
+        }
+
+        return $this->fetcher->fetchJson(rtrim($baseUrl, '/').'/api/icons');
+    }
+}

--- a/src/Tui/DeviceState/Prod/Transport/NotificationsTransport.php
+++ b/src/Tui/DeviceState/Prod/Transport/NotificationsTransport.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceState\Prod\Transport;
+
+use App\Tui\DeviceState\Prod\Http\HttpJsonFetcher;
+
+final class NotificationsTransport
+{
+    public function __construct(private readonly HttpJsonFetcher $fetcher)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function fetch(?string $baseUrl): ?array
+    {
+        if (null === $baseUrl || '' === $baseUrl) {
+            return null;
+        }
+
+        return $this->fetcher->fetchJson(rtrim($baseUrl, '/').'/api/notify/list');
+    }
+}

--- a/src/Tui/DeviceState/Prod/Transport/SettingsTransport.php
+++ b/src/Tui/DeviceState/Prod/Transport/SettingsTransport.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceState\Prod\Transport;
+
+use App\Tui\DeviceState\Prod\Http\HttpJsonFetcher;
+
+final class SettingsTransport
+{
+    public function __construct(private readonly HttpJsonFetcher $fetcher)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function fetch(?string $baseUrl): ?array
+    {
+        if (null === $baseUrl || '' === $baseUrl) {
+            return null;
+        }
+
+        return $this->fetcher->fetchJson(rtrim($baseUrl, '/').'/api/settings');
+    }
+}

--- a/src/Tui/DeviceState/Prod/Transport/TrackersTransport.php
+++ b/src/Tui/DeviceState/Prod/Transport/TrackersTransport.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceState\Prod\Transport;
+
+use App\Tui\DeviceState\Prod\Http\HttpJsonFetcher;
+
+final class TrackersTransport
+{
+    public function __construct(private readonly HttpJsonFetcher $fetcher)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function fetch(?string $baseUrl): ?array
+    {
+        if (null === $baseUrl || '' === $baseUrl) {
+            return null;
+        }
+
+        return $this->fetcher->fetchJson(rtrim($baseUrl, '/').'/api/trackers');
+    }
+}

--- a/src/Tui/DeviceState/Prod/Transport/WeatherTransport.php
+++ b/src/Tui/DeviceState/Prod/Transport/WeatherTransport.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\DeviceState\Prod\Transport;
+
+use App\Tui\DeviceState\Prod\Http\HttpJsonFetcher;
+
+final class WeatherTransport
+{
+    public function __construct(private readonly HttpJsonFetcher $fetcher)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function fetch(?string $baseUrl): ?array
+    {
+        if (null === $baseUrl || '' === $baseUrl) {
+            return null;
+        }
+
+        return $this->fetcher->fetchJson(rtrim($baseUrl, '/').'/api/weather');
+    }
+}

--- a/src/Tui/Inspector/StateFormatter.php
+++ b/src/Tui/Inspector/StateFormatter.php
@@ -4,19 +4,10 @@ declare(strict_types=1);
 
 namespace App\Tui\Inspector;
 
+use App\Domain\AppDomain;
+
 final class StateFormatter
 {
-    private const KNOWN_DOMAINS = [
-        'weather',
-        'trackers',
-        'notifications',
-        'customApps',
-        'indicators',
-        'brightness',
-        'settings',
-        'icons',
-    ];
-
     /**
      * @param array<string, mixed>|null $state
      */
@@ -26,9 +17,12 @@ final class StateFormatter
             return 'No data';
         }
 
+        $appDomainKeys = array_map(static fn (AppDomain $domain) => $domain->value, AppDomain::cases());
+        $orderedKeys = [...$appDomainKeys, 'brightness', 'settings'];
+
         $lines = [];
 
-        foreach (self::KNOWN_DOMAINS as $domain) {
+        foreach ($orderedKeys as $domain) {
             $lines[] = \sprintf('[%s]', $domain);
             if (!\array_key_exists($domain, $state)) {
                 $lines[] = '  (empty)';
@@ -37,7 +31,7 @@ final class StateFormatter
             self::appendBodyLines($lines, $state[$domain]);
         }
 
-        $extraDomains = array_diff(array_keys($state), self::KNOWN_DOMAINS);
+        $extraDomains = array_diff(array_keys($state), $orderedKeys);
         sort($extraDomains);
         foreach ($extraDomains as $domain) {
             $lines[] = \sprintf('[%s]', $domain);

--- a/tests/Domain/AppDomainTest.php
+++ b/tests/Domain/AppDomainTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Domain;
+
+use App\Domain\AppDomain;
+use PHPUnit\Framework\TestCase;
+
+final class AppDomainTest extends TestCase
+{
+    public function testEnumExposesSixAppDomainCases(): void
+    {
+        $expected = [
+            'Weather' => 'weather',
+            'Trackers' => 'trackers',
+            'Notifications' => 'notifications',
+            'CustomApps' => 'customApps',
+            'Indicators' => 'indicators',
+            'Icons' => 'icons',
+        ];
+
+        $actual = [];
+        foreach (AppDomain::cases() as $case) {
+            $actual[$case->name] = $case->value;
+        }
+
+        self::assertSame($expected, $actual);
+    }
+}

--- a/tests/Tui/DeviceState/Dev/DevDeviceStateSourceTest.php
+++ b/tests/Tui/DeviceState/Dev/DevDeviceStateSourceTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\DeviceState\Dev;
+
+use App\Domain\AppDomain;
+use App\Tui\DeviceState\Dev\DevDeviceStateSource;
+use App\Tui\Inspector\InspectorPoller;
+use App\Tui\Inspector\InspectorSnapshot;
+use App\Tui\Inspector\InspectorTransport;
+use PHPUnit\Framework\TestCase;
+
+final class DevDeviceStateSourceTest extends TestCase
+{
+    public function testRefreshDelegatesToInnerPoller(): void
+    {
+        $stubClient = new CountingInspectorHttpClientStub();
+        $poller = new InspectorPoller($stubClient, 'http://example.invalid', pollIntervalSeconds: 1.0);
+        $source = new DevDeviceStateSource($poller);
+
+        $beforeInterval = $source->refresh(0.0);
+        $atInterval = $source->refresh(1.5);
+
+        self::assertFalse($beforeInterval);
+        self::assertTrue($atInterval);
+        self::assertSame(1, $stubClient->fetchCount);
+    }
+
+    public function testGetDomainStateReturnsHasDataFalseWhenSnapshotIsNull(): void
+    {
+        $stubClient = new CountingInspectorHttpClientStub();
+        $poller = new InspectorPoller($stubClient, 'http://example.invalid', pollIntervalSeconds: 1.0);
+        $source = new DevDeviceStateSource($poller);
+
+        foreach (AppDomain::cases() as $domain) {
+            $state = $source->getDomainState($domain);
+            self::assertFalse($state->hasData, "Expected hasData=false for {$domain->value}");
+            self::assertNull($state->payload);
+        }
+    }
+
+    public function testGetDomainStateReturnsHasDataFalseWhenUnreachable(): void
+    {
+        $stubClient = new CountingInspectorHttpClientStub();
+        $stubClient->cannedSnapshot = InspectorSnapshot::unreachable('boom');
+        $poller = new InspectorPoller($stubClient, 'http://example.invalid', pollIntervalSeconds: 0.0001);
+        $source = new DevDeviceStateSource($poller);
+
+        $source->refresh(1.0);
+
+        foreach (AppDomain::cases() as $domain) {
+            $state = $source->getDomainState($domain);
+            self::assertFalse($state->hasData, "Expected hasData=false for {$domain->value}");
+            self::assertNull($state->payload);
+        }
+    }
+
+    public function testGetDomainStateForWeatherWithCurrentNotNullHasData(): void
+    {
+        $source = $this->buildSourceWithState(['weather' => ['current' => ['temp' => 20]]]);
+
+        $state = $source->getDomainState(AppDomain::Weather);
+
+        self::assertTrue($state->hasData);
+        self::assertSame(['current' => ['temp' => 20]], $state->payload);
+    }
+
+    public function testGetDomainStateForWeatherWithCurrentNullHasNoData(): void
+    {
+        $source = $this->buildSourceWithState(['weather' => ['current' => null]]);
+
+        $state = $source->getDomainState(AppDomain::Weather);
+
+        self::assertFalse($state->hasData);
+        self::assertSame(['current' => null], $state->payload);
+    }
+
+    public function testGetDomainStateForTrackersEmptyListHasNoData(): void
+    {
+        $source = $this->buildSourceWithState(['trackers' => ['trackers' => [], 'count' => 0]]);
+
+        $state = $source->getDomainState(AppDomain::Trackers);
+
+        self::assertFalse($state->hasData);
+    }
+
+    public function testGetDomainStateForTrackersWithItemsHasData(): void
+    {
+        $source = $this->buildSourceWithState(['trackers' => ['trackers' => [['id' => 1]], 'count' => 1]]);
+
+        $state = $source->getDomainState(AppDomain::Trackers);
+
+        self::assertTrue($state->hasData);
+        self::assertSame(['trackers' => [['id' => 1]], 'count' => 1], $state->payload);
+    }
+
+    public function testGetDomainStateForCustomAppsEmptyHasNoData(): void
+    {
+        $source = $this->buildSourceWithState(['customApps' => ['apps' => [], 'count' => 0]]);
+
+        $state = $source->getDomainState(AppDomain::CustomApps);
+
+        self::assertFalse($state->hasData);
+    }
+
+    public function testGetDomainStateForCustomAppsWithItemsHasData(): void
+    {
+        $source = $this->buildSourceWithState(['customApps' => ['apps' => [['id' => 'a1']], 'count' => 1]]);
+
+        $state = $source->getDomainState(AppDomain::CustomApps);
+
+        self::assertTrue($state->hasData);
+    }
+
+    public function testGetDomainStateForIndicatorsAllSlotsNullHasNoData(): void
+    {
+        $source = $this->buildSourceWithState([
+            'indicators' => ['slot1' => null, 'slot2' => null, 'slot3' => null],
+        ]);
+
+        $state = $source->getDomainState(AppDomain::Indicators);
+
+        self::assertFalse($state->hasData);
+    }
+
+    public function testGetDomainStateForIndicatorsAnySlotSetHasData(): void
+    {
+        $source = $this->buildSourceWithState([
+            'indicators' => ['slot1' => null, 'slot2' => ['color' => 'red'], 'slot3' => null],
+        ]);
+
+        $state = $source->getDomainState(AppDomain::Indicators);
+
+        self::assertTrue($state->hasData);
+    }
+
+    public function testGetDomainStateForNotificationsEmptyQueueHasNoData(): void
+    {
+        $source = $this->buildSourceWithState(['notifications' => ['queue' => []]]);
+
+        $state = $source->getDomainState(AppDomain::Notifications);
+
+        self::assertFalse($state->hasData);
+    }
+
+    public function testGetDomainStateForNotificationsWithItemsHasData(): void
+    {
+        $source = $this->buildSourceWithState(['notifications' => ['queue' => [['id' => 'x']], 'count' => 1, 'current' => null]]);
+
+        $state = $source->getDomainState(AppDomain::Notifications);
+
+        self::assertTrue($state->hasData);
+    }
+
+    public function testGetDomainStateForIconsEmptyHasNoData(): void
+    {
+        $source = $this->buildSourceWithState(['icons' => ['icons' => [], 'count' => 0]]);
+
+        $state = $source->getDomainState(AppDomain::Icons);
+
+        self::assertFalse($state->hasData);
+    }
+
+    public function testSnapshotReturnsAllSixAppDomainKeys(): void
+    {
+        $source = $this->buildSourceWithState([
+            'weather' => ['current' => ['temp' => 18]],
+            'trackers' => ['trackers' => [], 'count' => 0],
+            'notifications' => ['queue' => [['id' => 'n1']], 'count' => 1, 'current' => null],
+            'customApps' => ['apps' => [], 'count' => 0],
+            'indicators' => ['slot1' => ['color' => 'red'], 'slot2' => null, 'slot3' => null],
+            'icons' => ['icons' => [], 'count' => 0],
+        ]);
+
+        $snapshot = $source->snapshot();
+
+        self::assertSame(
+            ['weather', 'trackers', 'notifications', 'customApps', 'indicators', 'icons'],
+            array_keys($snapshot),
+        );
+        self::assertTrue($snapshot['weather']->hasData);
+        self::assertFalse($snapshot['trackers']->hasData);
+        self::assertTrue($snapshot['notifications']->hasData);
+        self::assertFalse($snapshot['customApps']->hasData);
+        self::assertTrue($snapshot['indicators']->hasData);
+        self::assertFalse($snapshot['icons']->hasData);
+    }
+
+    /**
+     * @param array<string, mixed> $state
+     */
+    private function buildSourceWithState(array $state): DevDeviceStateSource
+    {
+        $stubClient = new CountingInspectorHttpClientStub();
+        $stubClient->cannedSnapshot = InspectorSnapshot::fromInspectPayload(['state' => $state]);
+        $poller = new InspectorPoller($stubClient, 'http://example.invalid', pollIntervalSeconds: 0.0001);
+        $source = new DevDeviceStateSource($poller);
+        $source->refresh(1.0);
+
+        return $source;
+    }
+}
+
+final class CountingInspectorHttpClientStub implements InspectorTransport
+{
+    public int $fetchCount = 0;
+    public ?InspectorSnapshot $cannedSnapshot = null;
+
+    public function fetch(?string $baseUrl): InspectorSnapshot
+    {
+        ++$this->fetchCount;
+
+        return $this->cannedSnapshot ?? InspectorSnapshot::fromInspectPayload([
+            'state' => ['weather' => ['city' => 'Paris']],
+            'requests' => [],
+        ]);
+    }
+}

--- a/tests/Tui/DeviceState/Prod/ProdDeviceStateSourceTest.php
+++ b/tests/Tui/DeviceState/Prod/ProdDeviceStateSourceTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\DeviceState\Prod;
+
+use App\Domain\AppDomain;
+use App\Tui\DeviceState\Prod\Http\HttpJsonFetcher;
+use App\Tui\DeviceState\Prod\ProdDeviceStateSource;
+use App\Tui\DeviceState\Prod\Transport\IconsTransport;
+use App\Tui\DeviceState\Prod\Transport\NotificationsTransport;
+use App\Tui\DeviceState\Prod\Transport\SettingsTransport;
+use App\Tui\DeviceState\Prod\Transport\TrackersTransport;
+use App\Tui\DeviceState\Prod\Transport\WeatherTransport;
+use PHPUnit\Framework\TestCase;
+
+final class ProdDeviceStateSourceTest extends TestCase
+{
+    private const string BASE_URL = 'http://device.test';
+    private const string WEATHER_URL = self::BASE_URL.'/api/weather';
+    private const string TRACKERS_URL = self::BASE_URL.'/api/trackers';
+    private const string NOTIFICATIONS_URL = self::BASE_URL.'/api/notify/list';
+    private const string ICONS_URL = self::BASE_URL.'/api/icons';
+    private const string SETTINGS_URL = self::BASE_URL.'/api/settings';
+
+    public function testRefreshReturnsFalseBeforeInterval(): void
+    {
+        $fetcher = new StubHttpJsonFetcher();
+        $source = $this->buildSource($fetcher);
+
+        $result = $source->refresh(1.0);
+
+        self::assertFalse($result);
+        self::assertSame([], $fetcher->callCounts);
+    }
+
+    public function testRefreshReturnsTrueAfterIntervalElapsed(): void
+    {
+        $fetcher = new StubHttpJsonFetcher();
+        $source = $this->buildSource($fetcher);
+
+        $result = $source->refresh(2.5);
+
+        self::assertTrue($result);
+        self::assertSame(1, $fetcher->callCounts[self::WEATHER_URL] ?? 0);
+        self::assertSame(1, $fetcher->callCounts[self::TRACKERS_URL] ?? 0);
+        self::assertSame(1, $fetcher->callCounts[self::NOTIFICATIONS_URL] ?? 0);
+        self::assertSame(1, $fetcher->callCounts[self::ICONS_URL] ?? 0);
+        self::assertSame(1, $fetcher->callCounts[self::SETTINGS_URL] ?? 0);
+    }
+
+    public function testRefreshFiresOncePerAccumulatedInterval(): void
+    {
+        $fetcher = new StubHttpJsonFetcher();
+        $source = $this->buildSource($fetcher);
+
+        $firstResult = $source->refresh(2.5);
+        $secondResult = $source->refresh(2.5);
+
+        self::assertTrue($firstResult);
+        self::assertTrue($secondResult);
+        self::assertSame(2, $fetcher->callCounts[self::WEATHER_URL] ?? 0);
+        self::assertSame(2, $fetcher->callCounts[self::TRACKERS_URL] ?? 0);
+        self::assertSame(2, $fetcher->callCounts[self::NOTIFICATIONS_URL] ?? 0);
+        self::assertSame(2, $fetcher->callCounts[self::ICONS_URL] ?? 0);
+        self::assertSame(2, $fetcher->callCounts[self::SETTINGS_URL] ?? 0);
+    }
+
+    public function testGetDomainStateReturnsNoDataBeforeAnyRefresh(): void
+    {
+        $fetcher = new StubHttpJsonFetcher();
+        $source = $this->buildSource($fetcher);
+
+        foreach (AppDomain::cases() as $domain) {
+            $state = $source->getDomainState($domain);
+            self::assertFalse($state->hasData, "Expected hasData=false for {$domain->value}");
+            self::assertNull($state->payload);
+        }
+    }
+
+    public function testGetDomainStateWeatherHasDataWhenCurrentNotNull(): void
+    {
+        $fetcher = new StubHttpJsonFetcher();
+        $fetcher->responses[self::WEATHER_URL] = ['current' => ['temp' => 20]];
+        $source = $this->buildSource($fetcher);
+        $source->refresh(2.5);
+
+        $state = $source->getDomainState(AppDomain::Weather);
+
+        self::assertTrue($state->hasData);
+        self::assertSame(['current' => ['temp' => 20]], $state->payload);
+    }
+
+    public function testGetDomainStateWeatherHasNoDataWhenCurrentIsNull(): void
+    {
+        $fetcher = new StubHttpJsonFetcher();
+        $fetcher->responses[self::WEATHER_URL] = ['current' => null];
+        $source = $this->buildSource($fetcher);
+        $source->refresh(2.5);
+
+        $state = $source->getDomainState(AppDomain::Weather);
+
+        self::assertFalse($state->hasData);
+        self::assertSame(['current' => null], $state->payload);
+    }
+
+    public function testGetDomainStateTrackersEmptyHasNoData(): void
+    {
+        $fetcher = new StubHttpJsonFetcher();
+        $fetcher->responses[self::TRACKERS_URL] = ['trackers' => [], 'count' => 0];
+        $source = $this->buildSource($fetcher);
+        $source->refresh(2.5);
+
+        $state = $source->getDomainState(AppDomain::Trackers);
+
+        self::assertFalse($state->hasData);
+    }
+
+    public function testGetDomainStateTrackersWithItemsHasData(): void
+    {
+        $fetcher = new StubHttpJsonFetcher();
+        $fetcher->responses[self::TRACKERS_URL] = ['trackers' => [['name' => 'BTC']], 'count' => 1];
+        $source = $this->buildSource($fetcher);
+        $source->refresh(2.5);
+
+        $state = $source->getDomainState(AppDomain::Trackers);
+
+        self::assertTrue($state->hasData);
+        self::assertSame(['trackers' => [['name' => 'BTC']], 'count' => 1], $state->payload);
+    }
+
+    public function testGetDomainStateNotificationsEmptyHasNoData(): void
+    {
+        $fetcher = new StubHttpJsonFetcher();
+        $fetcher->responses[self::NOTIFICATIONS_URL] = ['count' => 0, 'currentIndex' => 0, 'notifications' => []];
+        $source = $this->buildSource($fetcher);
+        $source->refresh(2.5);
+
+        $state = $source->getDomainState(AppDomain::Notifications);
+
+        self::assertFalse($state->hasData);
+    }
+
+    public function testGetDomainStateNotificationsHasDataWhenListNonEmpty(): void
+    {
+        $fetcher = new StubHttpJsonFetcher();
+        $fetcher->responses[self::NOTIFICATIONS_URL] = [
+            'count' => 1,
+            'currentIndex' => 0,
+            'notifications' => [['text' => 'hello']],
+        ];
+        $source = $this->buildSource($fetcher);
+        $source->refresh(2.5);
+
+        $state = $source->getDomainState(AppDomain::Notifications);
+
+        self::assertTrue($state->hasData);
+    }
+
+    public function testGetDomainStateIconsHasDataWhenListNonEmpty(): void
+    {
+        $fetcher = new StubHttpJsonFetcher();
+        $fetcher->responses[self::ICONS_URL] = ['icons' => [['name' => 'x']]];
+        $source = $this->buildSource($fetcher);
+        $source->refresh(2.5);
+
+        $state = $source->getDomainState(AppDomain::Icons);
+
+        self::assertTrue($state->hasData);
+        self::assertSame(['icons' => [['name' => 'x']]], $state->payload);
+    }
+
+    public function testGetDomainStateIndicatorsAlwaysHasNoData(): void
+    {
+        $fetcher = new StubHttpJsonFetcher();
+        $source = $this->buildSource($fetcher);
+        $source->refresh(2.5);
+
+        $state = $source->getDomainState(AppDomain::Indicators);
+
+        self::assertFalse($state->hasData);
+        self::assertNull($state->payload);
+        self::assertArrayNotHasKey(self::BASE_URL.'/api/indicators', $fetcher->callCounts);
+    }
+
+    public function testGetDomainStateCustomAppsAlwaysHasNoData(): void
+    {
+        $fetcher = new StubHttpJsonFetcher();
+        $source = $this->buildSource($fetcher);
+        $source->refresh(2.5);
+
+        $state = $source->getDomainState(AppDomain::CustomApps);
+
+        self::assertFalse($state->hasData);
+        self::assertNull($state->payload);
+        self::assertArrayNotHasKey(self::BASE_URL.'/api/customapps', $fetcher->callCounts);
+        self::assertArrayNotHasKey(self::BASE_URL.'/api/customApps', $fetcher->callCounts);
+    }
+
+    public function testSnapshotReturnsAllSixAppDomainKeysAfterRefresh(): void
+    {
+        $fetcher = new StubHttpJsonFetcher();
+        $source = $this->buildSource($fetcher);
+        $source->refresh(2.5);
+
+        $snapshot = $source->snapshot();
+        $keys = array_keys($snapshot);
+        sort($keys);
+
+        $expected = ['customApps', 'icons', 'indicators', 'notifications', 'trackers', 'weather'];
+        sort($expected);
+        self::assertSame($expected, $keys);
+    }
+
+    public function testGetDomainStateReturnsNullPayloadWhenEndpointUnreachable(): void
+    {
+        $fetcher = new StubHttpJsonFetcher();
+        $source = $this->buildSource($fetcher);
+        $source->refresh(2.5);
+
+        $state = $source->getDomainState(AppDomain::Weather);
+
+        self::assertFalse($state->hasData);
+        self::assertNull($state->payload);
+    }
+
+    private function buildSource(StubHttpJsonFetcher $fetcher, float $interval = 2.0): ProdDeviceStateSource
+    {
+        return new ProdDeviceStateSource(
+            new WeatherTransport($fetcher),
+            new TrackersTransport($fetcher),
+            new NotificationsTransport($fetcher),
+            new IconsTransport($fetcher),
+            new SettingsTransport($fetcher),
+            self::BASE_URL,
+            $interval,
+        );
+    }
+}
+
+final class StubHttpJsonFetcher extends HttpJsonFetcher
+{
+    /** @var array<string, array<string, mixed>|null> */
+    public array $responses = [];
+
+    /** @var array<string, int> */
+    public array $callCounts = [];
+
+    public function __construct()
+    {
+        parent::__construct(0.001);
+    }
+
+    public function fetchJson(string $url): ?array
+    {
+        $this->callCounts[$url] = ($this->callCounts[$url] ?? 0) + 1;
+
+        return $this->responses[$url] ?? null;
+    }
+}

--- a/tests/Tui/Inspector/StateFormatterTest.php
+++ b/tests/Tui/Inspector/StateFormatterTest.php
@@ -45,12 +45,12 @@ final class StateFormatterTest extends TestCase
               installed: ["weather","clock"]
             [indicators]
               battery: true
+            [icons]
+              count: 3
             [brightness]
               level: 80
             [settings]
               theme: dark
-            [icons]
-              count: 3
             EOT;
 
         self::assertSame($expected, $output);


### PR DESCRIPTION
## Summary

Foundation for the TUI dashboard redesign: introduces the `AppDomain` enum and the `DeviceStateSource` contract with two implementations — a dev source wrapping `InspectorPoller` (`/__inspect`) and a prod source orchestrating five firmware endpoints (`/api/weather`, `/api/trackers`, `/api/notify/list`, `/api/icons`, `/api/settings`) in a single polling cycle per tick. `StateFormatter::KNOWN_DOMAINS` is removed in favour of `AppDomain::cases()`.

No UI is migrated in this ticket (Ticket 2 will plug the new contract into rendering). Indicators and CustomApps have no firmware endpoint and always report `hasData=false`; `/api/stats` stays on `StatsPoller`.

Closes #42