### PR TITLE
feat(tui): persistent collapsible domain blocks with readable renderers (#44)

### DIFF
--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -9,6 +9,9 @@ use App\Config\PixelCastConfigWriter;
 use App\Tui\Configuration\ConfigurationFieldValidator;
 use App\Tui\Configuration\Panel\ConfigurationPanel;
 use App\Tui\Configuration\SaveOutcome;
+use App\Tui\Dashboard\Panel\DashboardPanel;
+use App\Tui\DeviceState\Dev\DevDeviceStateSource;
+use App\Tui\DeviceState\DeviceStateSource;
 use App\Tui\DeviceState\Prod\Http\HttpJsonFetcher;
 use App\Tui\DeviceState\Prod\ProdDeviceStateSource;
 use App\Tui\DeviceState\Prod\Transport\IconsTransport;
@@ -19,6 +22,8 @@ use App\Tui\DeviceState\Prod\Transport\WeatherTransport;
 use App\Tui\DeviceStatus\Panel\DeviceStatusPanel;
 use App\Tui\DeviceStatus\StatsPoller;
 use App\Tui\DeviceStatus\StatsTransport;
+use App\Tui\Inspector\InspectorPoller;
+use App\Tui\Inspector\InspectorTransport;
 use App\Tui\Menu\TuiMenuFactory;
 use App\Tui\Reachability\DeviceReachabilityProbe;
 use App\Tui\Reachability\DeviceReachabilityResult;
@@ -67,6 +72,7 @@ final class TuiCommand extends Command
         private readonly PixelCastConfigWriter $pixelCastConfigWriter,
         private readonly ConfigurationFieldValidator $configurationFieldValidator,
         private readonly StatsTransport $statsHttpClient,
+        private readonly InspectorTransport $inspectorHttpClient,
     ) {
         parent::__construct();
     }
@@ -86,8 +92,6 @@ final class TuiCommand extends Command
         $contentZone = new ContainerWidget();
         $contentZone->expandVertically(true);
 
-        $prodDeviceStateSource = null;
-
         $scenariosPanel = new ScenariosPanel($this->scenarioCatalog, $mode);
 
         $syncNowPanel = null;
@@ -100,6 +104,7 @@ final class TuiCommand extends Command
         $configurationPanel = null;
         $statsPoller = null;
         $deviceStatusPanel = null;
+        $deviceStateSource = null;
         if (TuiMode::Prod === $mode) {
             $configurationPanel = new ConfigurationPanel(
                 $this->pixelCastConfigLoader,
@@ -115,7 +120,8 @@ final class TuiCommand extends Command
             $deviceStatusPanel->update($statsPoller->poll(), busy: false);
 
             $httpJsonFetcher = new HttpJsonFetcher();
-            $prodDeviceStateSource = new ProdDeviceStateSource(
+            // Firmware has no GET for indicator slots or custom apps; both blocks stay [off] in prod.
+            $deviceStateSource = new ProdDeviceStateSource(
                 new WeatherTransport($httpJsonFetcher),
                 new TrackersTransport($httpJsonFetcher),
                 new NotificationsTransport($httpJsonFetcher),
@@ -123,7 +129,14 @@ final class TuiCommand extends Command
                 new SettingsTransport($httpJsonFetcher),
                 $effectiveDeviceUrl,
             );
+        } else {
+            $inspectorPoller = new InspectorPoller($this->inspectorHttpClient, $this->deviceBaseUrl);
+            $deviceStateSource = new DevDeviceStateSource($inspectorPoller);
         }
+
+        $dashboardPanel = new DashboardPanel();
+        $dashboardPanel->update($deviceStateSource);
+        $contentZone->add($dashboardPanel->widget());
 
         $statusBar = new StatusBarWidget($mode);
         $statusBar->setBaseLine($this->buildStatusBarBaseLine(
@@ -161,11 +174,10 @@ final class TuiCommand extends Command
             ));
         }
 
-        if (null !== $prodDeviceStateSource) {
-            $tui->addListener($this->buildProdDeviceStateTickListener($prodDeviceStateSource));
-        }
+        $tui->addListener($this->buildDeviceStateTickListener($tui, $deviceStateSource, $dashboardPanel));
 
-        $tui->addListener(function (SelectEvent $event) use ($tui, $menuSelectList, $contentZone, $viewWidgets): void {
+        $dashboardWidget = $dashboardPanel->widget();
+        $tui->addListener(function (SelectEvent $event) use ($tui, $menuSelectList, $contentZone, $viewWidgets, $dashboardWidget): void {
             if ($event->getTarget() !== $menuSelectList) {
                 return;
             }
@@ -179,7 +191,7 @@ final class TuiCommand extends Command
                 return;
             }
 
-            $this->switchView($tui, $contentZone, $targetView, $viewWidgets);
+            $this->switchView($tui, $contentZone, $targetView, $viewWidgets, $dashboardWidget);
         });
 
         $tui->addListener(function (SelectEvent $event) use ($tui, $scenariosPanel, $mode): void {
@@ -197,13 +209,13 @@ final class TuiCommand extends Command
             $tui->requestRender();
         });
 
-        $tui->addListener(function (CancelEvent $event) use ($tui, $contentZone, $viewWidgets, $scenariosPanel): void {
+        $tui->addListener(function (CancelEvent $event) use ($tui, $contentZone, $viewWidgets, $scenariosPanel, $dashboardWidget): void {
             if ($event->getTarget() !== $scenariosPanel->selectListWidget()) {
                 return;
             }
 
             $scenariosPanel->clearResult();
-            $this->switchView($tui, $contentZone, TuiView::Main, $viewWidgets);
+            $this->switchView($tui, $contentZone, TuiView::Main, $viewWidgets, $dashboardWidget);
         });
 
         if (null !== $syncNowPanel) {
@@ -225,13 +237,13 @@ final class TuiCommand extends Command
                 $tui->requestRender();
             });
 
-            $tui->addListener(function (CancelEvent $event) use ($tui, $contentZone, $viewWidgets, $syncNowPanel): void {
+            $tui->addListener(function (CancelEvent $event) use ($tui, $contentZone, $viewWidgets, $syncNowPanel, $dashboardWidget): void {
                 if ($event->getTarget() !== $syncNowPanel->selectListWidget()) {
                     return;
                 }
 
                 $syncNowPanel->clearResult();
-                $this->switchView($tui, $contentZone, TuiView::Main, $viewWidgets);
+                $this->switchView($tui, $contentZone, TuiView::Main, $viewWidgets, $dashboardWidget);
             });
         }
 
@@ -246,38 +258,38 @@ final class TuiCommand extends Command
                 $tui->requestRender();
             });
 
-            $tui->addListener(function (CancelEvent $event) use ($tui, $contentZone, $viewWidgets, $resetSimPanel): void {
+            $tui->addListener(function (CancelEvent $event) use ($tui, $contentZone, $viewWidgets, $resetSimPanel, $dashboardWidget): void {
                 if ($event->getTarget() !== $resetSimPanel->selectListWidget()) {
                     return;
                 }
 
                 $resetSimPanel->clearResult();
-                $this->switchView($tui, $contentZone, TuiView::Main, $viewWidgets);
+                $this->switchView($tui, $contentZone, TuiView::Main, $viewWidgets, $dashboardWidget);
             });
         }
 
         if (null !== $configurationPanel) {
-            $tui->addListener(function (CancelEvent $event) use ($tui, $contentZone, $viewWidgets, $configurationPanel): void {
+            $tui->addListener(function (CancelEvent $event) use ($tui, $contentZone, $viewWidgets, $configurationPanel, $dashboardWidget): void {
                 if ($event->getTarget() !== $configurationPanel->selectListWidget()) {
                     return;
                 }
 
                 $configurationPanel->discardChanges();
-                $this->switchView($tui, $contentZone, TuiView::Main, $viewWidgets);
+                $this->switchView($tui, $contentZone, TuiView::Main, $viewWidgets, $dashboardWidget);
             });
         }
 
         if (null !== $deviceStatusPanel) {
-            $tui->addListener(function (CancelEvent $event) use ($tui, $contentZone, $viewWidgets): void {
+            $tui->addListener(function (CancelEvent $event) use ($tui, $contentZone, $viewWidgets, $dashboardWidget): void {
                 if (TuiView::DeviceStatus !== $this->currentView) {
                     return;
                 }
 
-                $this->switchView($tui, $contentZone, TuiView::Main, $viewWidgets);
+                $this->switchView($tui, $contentZone, TuiView::Main, $viewWidgets, $dashboardWidget);
             });
         }
 
-        $tui->addListener(function (InputEvent $event) use ($tui, $statusBar, $configurationPanel, $reachabilityResult): void {
+        $tui->addListener(function (InputEvent $event) use ($tui, $statusBar, $configurationPanel, $reachabilityResult, $dashboardPanel): void {
             $rawInput = $event->getData();
             if ('q' === $rawInput || 'Q' === $rawInput) {
                 $event->stopPropagation();
@@ -300,6 +312,34 @@ final class TuiCommand extends Command
                     ));
                 }
                 $tui->requestRender();
+
+                return;
+            }
+
+            if (TuiView::Main !== $this->currentView) {
+                return;
+            }
+
+            if ('k' === $rawInput || "\e[A" === $rawInput) {
+                $event->stopPropagation();
+                $dashboardPanel->selectPrevious();
+                $tui->requestRender();
+
+                return;
+            }
+
+            if ('j' === $rawInput || "\e[B" === $rawInput) {
+                $event->stopPropagation();
+                $dashboardPanel->selectNext();
+                $tui->requestRender();
+
+                return;
+            }
+
+            if ("\n" === $rawInput || "\r" === $rawInput || ' ' === $rawInput) {
+                $event->stopPropagation();
+                $dashboardPanel->toggleSelected();
+                $tui->requestRender();
             }
         });
 
@@ -309,8 +349,8 @@ final class TuiCommand extends Command
     }
 
     /**
-     * Swap the panel rendered inside the content zone. TuiView::Main means "no panel" —
-     * the content zone is cleared but the header and status bar remain visible.
+     * Swap the panel rendered inside the content zone. TuiView::Main re-installs
+     * the dashboard widget so its on/off blocks remain the default content.
      *
      * @param array<string, AbstractWidget> $viewWidgets keyed by TuiView::value
      */
@@ -319,6 +359,7 @@ final class TuiCommand extends Command
         ContainerWidget $contentZone,
         TuiView $next,
         array $viewWidgets,
+        AbstractWidget $mainWidget,
     ): void {
         if ($this->currentView === $next) {
             return;
@@ -331,7 +372,9 @@ final class TuiCommand extends Command
         $this->currentView = $next;
         $contentZone->clear();
 
-        if (TuiView::Main !== $next) {
+        if (TuiView::Main === $next) {
+            $contentZone->add($mainWidget);
+        } else {
             $contentZone->add($viewWidgets[$next->value]);
         }
 
@@ -358,15 +401,19 @@ final class TuiCommand extends Command
         };
     }
 
-    private function buildProdDeviceStateTickListener(
-        ProdDeviceStateSource $prodDeviceStateSource,
+    private function buildDeviceStateTickListener(
+        Tui $tui,
+        DeviceStateSource $deviceStateSource,
+        DashboardPanel $dashboardPanel,
     ): callable {
-        return static function (TickEvent $event) use ($prodDeviceStateSource): void {
-            if (!$prodDeviceStateSource->refresh($event->getDeltaTime())) {
+        return static function (TickEvent $event) use ($tui, $deviceStateSource, $dashboardPanel): void {
+            if (!$deviceStateSource->refresh($event->getDeltaTime())) {
                 return;
             }
 
             $event->setBusy(true);
+            $dashboardPanel->update($deviceStateSource);
+            $tui->requestRender();
         };
     }
 

--- a/src/Tui/Dashboard/CollapsibleBlock.php
+++ b/src/Tui/Dashboard/CollapsibleBlock.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Dashboard;
+
+use Symfony\Component\Tui\Style\Style;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+
+final class CollapsibleBlock
+{
+    private const string STATE_MARKER_ON = '[on]';
+    private const string STATE_MARKER_OFF = '[off]';
+    private const string SELECTION_PREFIX_SELECTED = '> ';
+    private const string SELECTION_PREFIX_UNSELECTED = '  ';
+    private const string EMPTY_BODY_TEXT = 'no data';
+
+    private readonly TextWidget $headerWidget;
+    private readonly TextWidget $bodyTextWidget;
+    private readonly ContainerWidget $bodyContainer;
+    private readonly ContainerWidget $outerContainer;
+
+    private bool $expanded = false;
+    private bool $hasData = false;
+    private bool $selected = false;
+
+    public function __construct(private readonly string $title)
+    {
+        $this->headerWidget = new TextWidget($this->renderHeaderLine());
+        $this->bodyTextWidget = new TextWidget(self::EMPTY_BODY_TEXT);
+
+        $this->bodyContainer = new ContainerWidget();
+        $this->bodyContainer->add($this->bodyTextWidget);
+        $this->bodyContainer->setStyle(new Style()->withHidden(true));
+
+        $this->outerContainer = new ContainerWidget();
+        $this->outerContainer->add($this->headerWidget);
+        $this->outerContainer->add($this->bodyContainer);
+    }
+
+    public function widget(): ContainerWidget
+    {
+        return $this->outerContainer;
+    }
+
+    public function toggle(): void
+    {
+        if ($this->expanded) {
+            $this->collapse();
+
+            return;
+        }
+        $this->expand();
+    }
+
+    public function expand(): void
+    {
+        $this->expanded = true;
+        $this->applyExpansionStyle();
+    }
+
+    public function collapse(): void
+    {
+        $this->expanded = false;
+        $this->applyExpansionStyle();
+    }
+
+    public function isExpanded(): bool
+    {
+        return $this->expanded;
+    }
+
+    public function setState(bool $hasData, string $bodyText): void
+    {
+        $this->hasData = $hasData;
+        $this->bodyTextWidget->setText($bodyText);
+        $this->headerWidget->setText($this->renderHeaderLine());
+    }
+
+    public function setSelected(bool $selected): void
+    {
+        $this->selected = $selected;
+        $this->headerWidget->setText($this->renderHeaderLine());
+    }
+
+    public function headerText(): string
+    {
+        return $this->headerWidget->getText();
+    }
+
+    public function bodyText(): string
+    {
+        return $this->bodyTextWidget->getText();
+    }
+
+    public function bodyContainer(): ContainerWidget
+    {
+        return $this->bodyContainer;
+    }
+
+    private function renderHeaderLine(): string
+    {
+        $selectionPrefix = $this->selected ? self::SELECTION_PREFIX_SELECTED : self::SELECTION_PREFIX_UNSELECTED;
+        $stateMarker = $this->hasData ? self::STATE_MARKER_ON : self::STATE_MARKER_OFF;
+
+        return $selectionPrefix.$this->title.' '.$stateMarker;
+    }
+
+    private function applyExpansionStyle(): void
+    {
+        $currentStyle = $this->bodyContainer->getStyle() ?? new Style();
+        $this->bodyContainer->setStyle($currentStyle->withHidden(!$this->expanded));
+    }
+}

--- a/src/Tui/Dashboard/Panel/DashboardPanel.php
+++ b/src/Tui/Dashboard/Panel/DashboardPanel.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Dashboard\Panel;
+
+use App\Domain\AppDomain;
+use App\Tui\Dashboard\CollapsibleBlock;
+use App\Tui\Dashboard\Renderer\CustomAppsRenderer;
+use App\Tui\Dashboard\Renderer\DomainRenderer;
+use App\Tui\Dashboard\Renderer\IconsRenderer;
+use App\Tui\Dashboard\Renderer\IndicatorsRenderer;
+use App\Tui\Dashboard\Renderer\NotificationsRenderer;
+use App\Tui\Dashboard\Renderer\TrackersRenderer;
+use App\Tui\Dashboard\Renderer\WeatherRenderer;
+use App\Tui\DeviceState\DeviceStateSource;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+
+final class DashboardPanel
+{
+    /** @var array<string, CollapsibleBlock> */
+    private readonly array $blocks;
+
+    /** @var array<string, DomainRenderer> */
+    private readonly array $renderers;
+
+    /** @var list<AppDomain> */
+    private readonly array $orderedDomains;
+
+    private readonly ContainerWidget $outerContainer;
+
+    private int $selectedBlockIndex = 0;
+
+    public function __construct()
+    {
+        $blocks = [];
+        foreach (AppDomain::cases() as $domain) {
+            $blocks[$domain->value] = new CollapsibleBlock(self::titleFor($domain));
+        }
+        $this->blocks = $blocks;
+
+        $this->renderers = [
+            AppDomain::Weather->value => new WeatherRenderer(),
+            AppDomain::Trackers->value => new TrackersRenderer(),
+            AppDomain::Notifications->value => new NotificationsRenderer(),
+            AppDomain::CustomApps->value => new CustomAppsRenderer(),
+            AppDomain::Indicators->value => new IndicatorsRenderer(),
+            AppDomain::Icons->value => new IconsRenderer(),
+        ];
+
+        $this->orderedDomains = AppDomain::cases();
+
+        $this->outerContainer = new ContainerWidget();
+        $this->outerContainer->expandVertically(true);
+        foreach ($this->orderedDomains as $domain) {
+            $this->outerContainer->add($this->blocks[$domain->value]->widget());
+        }
+
+        $this->selectedBlock()->setSelected(true);
+    }
+
+    public function widget(): ContainerWidget
+    {
+        return $this->outerContainer;
+    }
+
+    public function update(DeviceStateSource $source): void
+    {
+        foreach ($this->orderedDomains as $domain) {
+            $state = $source->getDomainState($domain);
+            $body = $this->renderers[$domain->value]->render($state);
+            $this->blocks[$domain->value]->setState($state->hasData, $body);
+        }
+    }
+
+    public function selectedDomain(): AppDomain
+    {
+        return $this->orderedDomains[$this->selectedBlockIndex];
+    }
+
+    public function selectNext(): void
+    {
+        $this->moveSelection(1);
+    }
+
+    public function selectPrevious(): void
+    {
+        $this->moveSelection(-1);
+    }
+
+    public function toggleSelected(): void
+    {
+        $this->selectedBlock()->toggle();
+    }
+
+    public function block(AppDomain $domain): CollapsibleBlock
+    {
+        return $this->blocks[$domain->value];
+    }
+
+    private function moveSelection(int $delta): void
+    {
+        $totalDomains = \count($this->orderedDomains);
+        $this->selectedBlock()->setSelected(false);
+        $this->selectedBlockIndex = ($this->selectedBlockIndex + $delta + $totalDomains) % $totalDomains;
+        $this->selectedBlock()->setSelected(true);
+    }
+
+    private function selectedBlock(): CollapsibleBlock
+    {
+        return $this->blocks[$this->orderedDomains[$this->selectedBlockIndex]->value];
+    }
+
+    private static function titleFor(AppDomain $domain): string
+    {
+        return match ($domain) {
+            AppDomain::Weather => 'Weather',
+            AppDomain::Trackers => 'Trackers',
+            AppDomain::Notifications => 'Notifications',
+            AppDomain::CustomApps => 'Custom Apps',
+            AppDomain::Indicators => 'Indicators',
+            AppDomain::Icons => 'Icons',
+        };
+    }
+}

--- a/src/Tui/Dashboard/Renderer/CustomAppsRenderer.php
+++ b/src/Tui/Dashboard/Renderer/CustomAppsRenderer.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Dashboard\Renderer;
+
+use App\Tui\DeviceState\DeviceDomainState;
+use App\Tui\TerminalSafeText;
+
+final class CustomAppsRenderer implements DomainRenderer
+{
+    private const string NO_DATA_TEXT = 'no data';
+    private const int MAX_NAMES = 5;
+
+    public function render(DeviceDomainState $state): string
+    {
+        if (false === $state->hasData) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $payload = $state->payload;
+        if (!\is_array($payload)) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $apps = $payload['apps'] ?? null;
+        if (!\is_array($apps) || [] === $apps) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $names = [];
+        foreach ($apps as $app) {
+            $name = $this->extractAppName($app);
+            if (null === $name) {
+                continue;
+            }
+            $names[] = $name;
+        }
+
+        $totalCount = \count($apps);
+        $previewNames = \array_slice($names, 0, self::MAX_NAMES);
+
+        $lines = ['Count: '.$totalCount];
+        foreach ($previewNames as $previewName) {
+            $lines[] = '- '.$previewName;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private function extractAppName(mixed $app): ?string
+    {
+        if (\is_string($app)) {
+            return '' === $app ? null : TerminalSafeText::stripControlBytes($app);
+        }
+        if (\is_array($app)) {
+            $name = $app['name'] ?? null;
+            if (\is_string($name) && '' !== $name) {
+                return TerminalSafeText::stripControlBytes($name);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Tui/Dashboard/Renderer/DomainRenderer.php
+++ b/src/Tui/Dashboard/Renderer/DomainRenderer.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Dashboard\Renderer;
+
+use App\Tui\DeviceState\DeviceDomainState;
+
+interface DomainRenderer
+{
+    public function render(DeviceDomainState $state): string;
+}

--- a/src/Tui/Dashboard/Renderer/IconsRenderer.php
+++ b/src/Tui/Dashboard/Renderer/IconsRenderer.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Dashboard\Renderer;
+
+use App\Tui\DeviceState\DeviceDomainState;
+use App\Tui\TerminalSafeText;
+
+final class IconsRenderer implements DomainRenderer
+{
+    private const string NO_DATA_TEXT = 'no data';
+    private const int MAX_NAMES = 5;
+
+    public function render(DeviceDomainState $state): string
+    {
+        if (false === $state->hasData) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $payload = $state->payload;
+        if (!\is_array($payload)) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $icons = $payload['icons'] ?? null;
+        if (!\is_array($icons) || [] === $icons) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $names = [];
+        foreach ($icons as $icon) {
+            $name = $this->extractIconName($icon);
+            if (null === $name) {
+                continue;
+            }
+            $names[] = $name;
+        }
+
+        $totalCount = \count($icons);
+        $previewNames = \array_slice($names, 0, self::MAX_NAMES);
+
+        $lines = ['Count: '.$totalCount];
+        foreach ($previewNames as $previewName) {
+            $lines[] = '- '.$previewName;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private function extractIconName(mixed $icon): ?string
+    {
+        if (\is_string($icon)) {
+            return '' === $icon ? null : TerminalSafeText::stripControlBytes($icon);
+        }
+        if (\is_array($icon)) {
+            $name = $icon['name'] ?? null;
+            if (\is_string($name) && '' !== $name) {
+                return TerminalSafeText::stripControlBytes($name);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Tui/Dashboard/Renderer/IndicatorsRenderer.php
+++ b/src/Tui/Dashboard/Renderer/IndicatorsRenderer.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Dashboard\Renderer;
+
+use App\Tui\DeviceState\DeviceDomainState;
+use App\Tui\TerminalSafeText;
+
+final class IndicatorsRenderer implements DomainRenderer
+{
+    private const string NO_DATA_TEXT = 'no data';
+    private const string EMPTY_SLOT_TEXT = '-';
+
+    /** @var list<string> */
+    private const array SLOT_KEYS = ['slot1', 'slot2', 'slot3'];
+
+    public function render(DeviceDomainState $state): string
+    {
+        if (false === $state->hasData) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $payload = $state->payload;
+        if (!\is_array($payload)) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $lines = [];
+        foreach (self::SLOT_KEYS as $slotKey) {
+            $lines[] = $slotKey.': '.$this->formatSlotLabel($payload[$slotKey] ?? null);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private function formatSlotLabel(mixed $slot): string
+    {
+        if (null === $slot) {
+            return self::EMPTY_SLOT_TEXT;
+        }
+        if (\is_string($slot)) {
+            return '' === $slot ? self::EMPTY_SLOT_TEXT : TerminalSafeText::stripControlBytes($slot);
+        }
+        if (\is_array($slot)) {
+            $label = $slot['label'] ?? $slot['name'] ?? null;
+            if (\is_string($label) && '' !== $label) {
+                return TerminalSafeText::stripControlBytes($label);
+            }
+        }
+
+        return self::EMPTY_SLOT_TEXT;
+    }
+}

--- a/src/Tui/Dashboard/Renderer/NotificationsRenderer.php
+++ b/src/Tui/Dashboard/Renderer/NotificationsRenderer.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Dashboard\Renderer;
+
+use App\Tui\DeviceState\DeviceDomainState;
+use App\Tui\TerminalSafeText;
+
+final class NotificationsRenderer implements DomainRenderer
+{
+    private const string NO_DATA_TEXT = 'no data';
+    private const int MAX_ROWS = 8;
+
+    public function render(DeviceDomainState $state): string
+    {
+        if (false === $state->hasData) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $payload = $state->payload;
+        if (!\is_array($payload)) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $notifications = $this->extractNotifications($payload);
+        if ([] === $notifications) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $lines = [];
+        $count = 0;
+        foreach ($notifications as $notification) {
+            if ($count >= self::MAX_ROWS) {
+                break;
+            }
+            $line = $this->renderNotificationLine($notification);
+            if (null === $line) {
+                continue;
+            }
+            $lines[] = $line;
+            ++$count;
+        }
+
+        if ([] === $lines) {
+            return self::NO_DATA_TEXT;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param array<mixed> $payload
+     *
+     * @return list<mixed>
+     */
+    private function extractNotifications(array $payload): array
+    {
+        $queue = $payload['queue'] ?? $payload['notifications'] ?? null;
+        if (!\is_array($queue)) {
+            return [];
+        }
+
+        return array_values($queue);
+    }
+
+    private function renderNotificationLine(mixed $notification): ?string
+    {
+        if (!\is_array($notification)) {
+            return null;
+        }
+
+        $priority = $this->formatString($notification['priority'] ?? null);
+        $text = $this->formatString($notification['text'] ?? $notification['message'] ?? null);
+
+        if (null === $text) {
+            return null;
+        }
+
+        if (null === $priority) {
+            return $text;
+        }
+
+        return '['.$priority.'] '.$text;
+    }
+
+    private function formatString(mixed $value): ?string
+    {
+        if (\is_int($value) || \is_float($value)) {
+            return TerminalSafeText::stripControlBytes((string) $value);
+        }
+        if (!\is_string($value) || '' === $value) {
+            return null;
+        }
+
+        return TerminalSafeText::stripControlBytes($value);
+    }
+}

--- a/src/Tui/Dashboard/Renderer/TrackersRenderer.php
+++ b/src/Tui/Dashboard/Renderer/TrackersRenderer.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Dashboard\Renderer;
+
+use App\Tui\DeviceState\DeviceDomainState;
+use App\Tui\TerminalSafeText;
+
+final class TrackersRenderer implements DomainRenderer
+{
+    private const string NO_DATA_TEXT = 'no data';
+    private const int MAX_ROWS = 8;
+
+    public function render(DeviceDomainState $state): string
+    {
+        if (false === $state->hasData) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $payload = $state->payload;
+        if (!\is_array($payload)) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $trackers = $payload['trackers'] ?? null;
+        if (!\is_array($trackers) || [] === $trackers) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $lines = [];
+        $count = 0;
+        foreach ($trackers as $tracker) {
+            if ($count >= self::MAX_ROWS) {
+                break;
+            }
+            $line = $this->renderTrackerLine($tracker);
+            if (null === $line) {
+                continue;
+            }
+            $lines[] = $line;
+            ++$count;
+        }
+
+        if ([] === $lines) {
+            return self::NO_DATA_TEXT;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private function renderTrackerLine(mixed $tracker): ?string
+    {
+        if (!\is_array($tracker)) {
+            return null;
+        }
+
+        $label = $this->formatString($tracker['label'] ?? $tracker['name'] ?? null);
+        $value = $this->formatScalar($tracker['value'] ?? null);
+
+        if (null === $label && null === $value) {
+            return null;
+        }
+
+        $labelText = $label ?? '-';
+        $valueText = $value ?? '-';
+
+        return $labelText.': '.$valueText;
+    }
+
+    private function formatString(mixed $value): ?string
+    {
+        if (!\is_string($value) || '' === $value) {
+            return null;
+        }
+
+        return TerminalSafeText::stripControlBytes($value);
+    }
+
+    private function formatScalar(mixed $value): ?string
+    {
+        if (\is_string($value)) {
+            if ('' === $value) {
+                return null;
+            }
+
+            return TerminalSafeText::stripControlBytes($value);
+        }
+        if (\is_int($value) || \is_float($value)) {
+            return TerminalSafeText::stripControlBytes((string) $value);
+        }
+        if (\is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return null;
+    }
+}

--- a/src/Tui/Dashboard/Renderer/WeatherRenderer.php
+++ b/src/Tui/Dashboard/Renderer/WeatherRenderer.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Dashboard\Renderer;
+
+use App\Tui\DeviceState\DeviceDomainState;
+use App\Tui\TerminalSafeText;
+
+final class WeatherRenderer implements DomainRenderer
+{
+    private const string NO_DATA_TEXT = 'no data';
+    private const int MAX_FORECAST_LINES = 3;
+
+    public function render(DeviceDomainState $state): string
+    {
+        if (false === $state->hasData) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $payload = $state->payload;
+        if (!\is_array($payload)) {
+            return self::NO_DATA_TEXT;
+        }
+
+        $lines = [];
+
+        $currentLine = $this->renderCurrentLine($payload['current'] ?? null);
+        if (null !== $currentLine) {
+            $lines[] = $currentLine;
+        }
+
+        foreach ($this->renderForecastLines($payload['forecast'] ?? null) as $forecastLine) {
+            $lines[] = $forecastLine;
+        }
+
+        if ([] === $lines) {
+            return self::NO_DATA_TEXT;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private function renderCurrentLine(mixed $current): ?string
+    {
+        if (!\is_array($current)) {
+            return null;
+        }
+
+        $temperature = $this->formatTemperature($current['tempC'] ?? null);
+        $condition = $this->formatString($current['condition'] ?? null);
+
+        if (null === $temperature && null === $condition) {
+            return null;
+        }
+
+        $parts = ['Now:'];
+        if (null !== $temperature) {
+            $parts[] = $temperature;
+        }
+        if (null !== $condition) {
+            $parts[] = $condition;
+        }
+
+        return implode(' ', $parts);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function renderForecastLines(mixed $forecast): array
+    {
+        if (!\is_array($forecast)) {
+            return [];
+        }
+
+        $lines = [];
+        $count = 0;
+        foreach ($forecast as $entry) {
+            if ($count >= self::MAX_FORECAST_LINES) {
+                break;
+            }
+            $line = $this->renderForecastEntry($entry);
+            if (null === $line) {
+                continue;
+            }
+            $lines[] = $line;
+            ++$count;
+        }
+
+        return $lines;
+    }
+
+    private function renderForecastEntry(mixed $entry): ?string
+    {
+        if (!\is_array($entry)) {
+            return null;
+        }
+
+        $day = $this->formatString($entry['day'] ?? $entry['date'] ?? null);
+        $minTemperature = $this->formatTemperature($entry['minC'] ?? null);
+        $maxTemperature = $this->formatTemperature($entry['maxC'] ?? null);
+        $condition = $this->formatString($entry['condition'] ?? null);
+
+        $parts = [];
+        if (null !== $day) {
+            $parts[] = $day.':';
+        }
+        if (null !== $minTemperature && null !== $maxTemperature) {
+            $parts[] = $minTemperature.'/'.$maxTemperature;
+        } elseif (null !== $maxTemperature) {
+            $parts[] = $maxTemperature;
+        }
+        if (null !== $condition) {
+            $parts[] = $condition;
+        }
+
+        if ([] === $parts) {
+            return null;
+        }
+
+        return implode(' ', $parts);
+    }
+
+    private function formatTemperature(mixed $value): ?string
+    {
+        if (\is_int($value) || \is_float($value)) {
+            return TerminalSafeText::stripControlBytes((string) $value.'C');
+        }
+        if (\is_string($value) && '' !== $value) {
+            return TerminalSafeText::stripControlBytes($value.'C');
+        }
+
+        return null;
+    }
+
+    private function formatString(mixed $value): ?string
+    {
+        if (!\is_string($value) || '' === $value) {
+            return null;
+        }
+
+        return TerminalSafeText::stripControlBytes($value);
+    }
+}

--- a/tests/Command/TuiCommandWiringTest.php
+++ b/tests/Command/TuiCommandWiringTest.php
@@ -10,6 +10,8 @@ use App\Config\PixelCastConfigWriter;
 use App\Tui\Configuration\ConfigurationFieldValidator;
 use App\Tui\DeviceStatus\StatsHttpClient;
 use App\Tui\DeviceStatus\StatsTransport;
+use App\Tui\Inspector\InspectorHttpClient;
+use App\Tui\Inspector\InspectorTransport;
 use App\Tui\ResetSim\ResetSimulatorAction;
 use App\Tui\Scenarios\ScenarioCatalog;
 use App\Tui\Scenarios\ScenarioDispatcher;
@@ -117,5 +119,14 @@ final class TuiCommandWiringTest extends KernelTestCase
         $transport = self::getContainer()->get(StatsTransport::class);
 
         self::assertInstanceOf(StatsHttpClient::class, $transport);
+    }
+
+    public function testInspectorTransportResolvesToInspectorHttpClient(): void
+    {
+        self::bootKernel();
+
+        $transport = self::getContainer()->get(InspectorTransport::class);
+
+        self::assertInstanceOf(InspectorHttpClient::class, $transport);
     }
 }

--- a/tests/Tui/Dashboard/CollapsibleBlockTest.php
+++ b/tests/Tui/Dashboard/CollapsibleBlockTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Dashboard;
+
+use App\Tui\Dashboard\CollapsibleBlock;
+use PHPUnit\Framework\TestCase;
+
+final class CollapsibleBlockTest extends TestCase
+{
+    public function testInitialStateIsCollapsedAndOffWithHiddenBody(): void
+    {
+        $block = new CollapsibleBlock('Weather');
+
+        self::assertFalse($block->isExpanded());
+        self::assertSame('  Weather [off]', $block->headerText());
+        self::assertSame('no data', $block->bodyText());
+
+        $bodyStyle = $block->bodyContainer()->getStyle();
+        self::assertNotNull($bodyStyle);
+        self::assertTrue($bodyStyle->getHidden());
+    }
+
+    public function testExpandRemovesHiddenFlagAndFlipsExpandedFlag(): void
+    {
+        $block = new CollapsibleBlock('Weather');
+
+        $block->expand();
+
+        self::assertTrue($block->isExpanded());
+        $bodyStyle = $block->bodyContainer()->getStyle();
+        self::assertNotNull($bodyStyle);
+        self::assertFalse($bodyStyle->getHidden());
+    }
+
+    public function testCollapseRestoresHiddenFlag(): void
+    {
+        $block = new CollapsibleBlock('Weather');
+        $block->expand();
+
+        $block->collapse();
+
+        self::assertFalse($block->isExpanded());
+        $bodyStyle = $block->bodyContainer()->getStyle();
+        self::assertNotNull($bodyStyle);
+        self::assertTrue($bodyStyle->getHidden());
+    }
+
+    public function testToggleRoundTripsBetweenExpandedAndCollapsed(): void
+    {
+        $block = new CollapsibleBlock('Weather');
+
+        $block->toggle();
+        self::assertTrue($block->isExpanded());
+
+        $block->toggle();
+        self::assertFalse($block->isExpanded());
+
+        $block->toggle();
+        self::assertTrue($block->isExpanded());
+    }
+
+    public function testSetStateWithHasDataTrueWritesOnMarkerAndBodyText(): void
+    {
+        $block = new CollapsibleBlock('Weather');
+
+        $block->setState(true, 'foo');
+
+        self::assertSame('  Weather [on]', $block->headerText());
+        self::assertSame('foo', $block->bodyText());
+    }
+
+    public function testSetStateWithHasDataFalseWritesOffMarkerAndNoDataBody(): void
+    {
+        $block = new CollapsibleBlock('Weather');
+        $block->setState(true, 'foo');
+
+        $block->setState(false, 'no data');
+
+        self::assertSame('  Weather [off]', $block->headerText());
+        self::assertSame('no data', $block->bodyText());
+    }
+
+    public function testSetSelectedTruePrependsSelectionArrowOnHeader(): void
+    {
+        $block = new CollapsibleBlock('Weather');
+
+        $block->setSelected(true);
+
+        self::assertSame('> Weather [off]', $block->headerText());
+    }
+
+    public function testSetSelectedFalseRestoresUnselectedPrefix(): void
+    {
+        $block = new CollapsibleBlock('Weather');
+        $block->setSelected(true);
+
+        $block->setSelected(false);
+
+        self::assertSame('  Weather [off]', $block->headerText());
+    }
+
+    public function testHeaderReflectsBothSelectionAndStateMarker(): void
+    {
+        $block = new CollapsibleBlock('Trackers');
+
+        $block->setSelected(true);
+        $block->setState(true, 'body');
+
+        self::assertSame('> Trackers [on]', $block->headerText());
+    }
+}

--- a/tests/Tui/Dashboard/Panel/DashboardPanelTest.php
+++ b/tests/Tui/Dashboard/Panel/DashboardPanelTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Dashboard\Panel;
+
+use App\Domain\AppDomain;
+use App\Tui\Dashboard\Panel\DashboardPanel;
+use App\Tui\DeviceState\DeviceDomainState;
+use App\Tui\DeviceState\DeviceStateSource;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+
+final class DashboardPanelTest extends TestCase
+{
+    public function testConstructionBuildsSixCollapsedBlocksWithWeatherSelected(): void
+    {
+        $panel = new DashboardPanel();
+
+        foreach (AppDomain::cases() as $domain) {
+            $block = $panel->block($domain);
+            self::assertFalse($block->isExpanded(), "Expected {$domain->value} block to be collapsed at construction.");
+        }
+
+        self::assertSame(AppDomain::Weather, $panel->selectedDomain());
+        self::assertStringStartsWith('> ', $panel->block(AppDomain::Weather)->headerText());
+    }
+
+    public function testWidgetIsContainerWithSixChildren(): void
+    {
+        $panel = new DashboardPanel();
+
+        $widget = $panel->widget();
+
+        self::assertInstanceOf(ContainerWidget::class, $widget);
+        self::assertCount(6, $widget->all());
+    }
+
+    public function testSelectNextMovesSelectionToTrackersAndUpdatesHeaders(): void
+    {
+        $panel = new DashboardPanel();
+
+        $panel->selectNext();
+
+        self::assertSame(AppDomain::Trackers, $panel->selectedDomain());
+        self::assertStringStartsNotWith('> ', $panel->block(AppDomain::Weather)->headerText());
+        self::assertStringStartsWith('> ', $panel->block(AppDomain::Trackers)->headerText());
+    }
+
+    public function testSixSelectNextCallsWrapAroundToWeather(): void
+    {
+        $panel = new DashboardPanel();
+
+        for ($i = 0; $i < 6; ++$i) {
+            $panel->selectNext();
+        }
+
+        self::assertSame(AppDomain::Weather, $panel->selectedDomain());
+    }
+
+    public function testSelectPreviousFromWeatherWrapsToLastEnumCase(): void
+    {
+        $panel = new DashboardPanel();
+        $allDomains = AppDomain::cases();
+        $expectedLast = $allDomains[\count($allDomains) - 1];
+
+        $panel->selectPrevious();
+
+        self::assertSame($expectedLast, $panel->selectedDomain());
+        self::assertStringStartsWith('> ', $panel->block($expectedLast)->headerText());
+        self::assertStringStartsNotWith('> ', $panel->block(AppDomain::Weather)->headerText());
+    }
+
+    public function testToggleSelectedFlipsOnlySelectedBlockExpansion(): void
+    {
+        $panel = new DashboardPanel();
+
+        $panel->toggleSelected();
+
+        self::assertTrue($panel->block(AppDomain::Weather)->isExpanded());
+        foreach (AppDomain::cases() as $domain) {
+            if (AppDomain::Weather === $domain) {
+                continue;
+            }
+            self::assertFalse(
+                $panel->block($domain)->isExpanded(),
+                "Expected {$domain->value} to remain collapsed after toggling Weather.",
+            );
+        }
+    }
+
+    public function testUpdateAppliesRendererOutputAndStateMarkersPerDomain(): void
+    {
+        $statesByDomainValue = [
+            AppDomain::Weather->value => new DeviceDomainState(true, [
+                'current' => ['tempC' => 21, 'condition' => 'sunny'],
+            ]),
+            AppDomain::Trackers->value => new DeviceDomainState(false, null),
+            AppDomain::Notifications->value => new DeviceDomainState(false, null),
+            AppDomain::CustomApps->value => new DeviceDomainState(false, null),
+            AppDomain::Indicators->value => new DeviceDomainState(false, null),
+            AppDomain::Icons->value => new DeviceDomainState(false, null),
+        ];
+        $source = new StubDeviceStateSource($statesByDomainValue);
+        $panel = new DashboardPanel();
+
+        $panel->update($source);
+
+        $weatherBlock = $panel->block(AppDomain::Weather);
+        self::assertStringContainsString('[on]', $weatherBlock->headerText());
+        self::assertStringContainsString('21', $weatherBlock->bodyText());
+        self::assertStringContainsString('sunny', $weatherBlock->bodyText());
+
+        foreach ([AppDomain::Trackers, AppDomain::Notifications, AppDomain::CustomApps, AppDomain::Indicators, AppDomain::Icons] as $domain) {
+            $block = $panel->block($domain);
+            self::assertStringContainsString('[off]', $block->headerText());
+            self::assertSame('no data', $block->bodyText());
+        }
+    }
+
+    public function testUpdateStripsControlBytesFromRenderedBodyText(): void
+    {
+        $statesByDomainValue = [
+            AppDomain::Weather->value => new DeviceDomainState(true, [
+                'current' => ['tempC' => 21, 'condition' => "\x1b[31mhostile\x1b[0m"],
+            ]),
+        ];
+        $source = new StubDeviceStateSource($statesByDomainValue);
+        $panel = new DashboardPanel();
+
+        $panel->update($source);
+
+        $weatherBodyText = $panel->block(AppDomain::Weather)->bodyText();
+        self::assertStringNotContainsString("\x1b", $weatherBodyText);
+    }
+
+    public function testToggleSelectedRevealsOnlySelectedBlockBodyAndKeepsOthersHidden(): void
+    {
+        $statesByDomainValue = [
+            AppDomain::Weather->value => new DeviceDomainState(true, [
+                'current' => ['tempC' => 21, 'condition' => 'sunny'],
+            ]),
+        ];
+        $source = new StubDeviceStateSource($statesByDomainValue);
+        $panel = new DashboardPanel();
+
+        $panel->update($source);
+        $panel->toggleSelected();
+
+        $weatherHidden = $panel->block(AppDomain::Weather)->bodyContainer()->getStyle()?->getHidden();
+        self::assertNotTrue($weatherHidden);
+
+        foreach ([AppDomain::Trackers, AppDomain::Notifications, AppDomain::CustomApps, AppDomain::Indicators, AppDomain::Icons] as $domain) {
+            $hidden = $panel->block($domain)->bodyContainer()->getStyle()?->getHidden();
+            self::assertTrue($hidden, "Expected {$domain->value} body to remain hidden after toggling Weather.");
+        }
+    }
+}
+
+final class StubDeviceStateSource implements DeviceStateSource
+{
+    /**
+     * @param array<string, DeviceDomainState> $statesByDomainValue
+     */
+    public function __construct(
+        private readonly array $statesByDomainValue,
+    ) {
+    }
+
+    public function getDomainState(AppDomain $domain): DeviceDomainState
+    {
+        return $this->statesByDomainValue[$domain->value] ?? new DeviceDomainState(false, null);
+    }
+
+    public function snapshot(): array
+    {
+        return $this->statesByDomainValue;
+    }
+
+    public function refresh(float $deltaSeconds): bool
+    {
+        return true;
+    }
+}

--- a/tests/Tui/Dashboard/Renderer/CustomAppsRendererTest.php
+++ b/tests/Tui/Dashboard/Renderer/CustomAppsRendererTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Dashboard\Renderer;
+
+use App\Tui\Dashboard\Renderer\CustomAppsRenderer;
+use App\Tui\DeviceState\DeviceDomainState;
+use PHPUnit\Framework\TestCase;
+
+final class CustomAppsRendererTest extends TestCase
+{
+    public function testHasDataFalseReturnsNoData(): void
+    {
+        $renderer = new CustomAppsRenderer();
+        $state = new DeviceDomainState(false, null);
+
+        self::assertSame('no data', $renderer->render($state));
+    }
+
+    public function testEmptyAppsArrayReturnsNoData(): void
+    {
+        $renderer = new CustomAppsRenderer();
+        $state = new DeviceDomainState(true, ['apps' => []]);
+
+        self::assertSame('no data', $renderer->render($state));
+    }
+
+    public function testListOfStringsRendersCountAndNames(): void
+    {
+        $renderer = new CustomAppsRenderer();
+        $state = new DeviceDomainState(true, [
+            'apps' => ['stocks', 'agenda'],
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringContainsString('Count: 2', $output);
+        self::assertStringContainsString('- stocks', $output);
+        self::assertStringContainsString('- agenda', $output);
+    }
+
+    public function testListOfObjectsRendersCountAndNames(): void
+    {
+        $renderer = new CustomAppsRenderer();
+        $state = new DeviceDomainState(true, [
+            'apps' => [
+                ['name' => 'stocks'],
+                ['name' => 'agenda'],
+                ['name' => 'sport'],
+            ],
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringContainsString('Count: 3', $output);
+        self::assertStringContainsString('- stocks', $output);
+        self::assertStringContainsString('- agenda', $output);
+        self::assertStringContainsString('- sport', $output);
+    }
+
+    public function testNameListIsTruncatedToFive(): void
+    {
+        $renderer = new CustomAppsRenderer();
+        $state = new DeviceDomainState(true, [
+            'apps' => ['a1', 'a2', 'a3', 'a4', 'a5', 'a6'],
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringContainsString('Count: 6', $output);
+        self::assertStringContainsString('- a5', $output);
+        self::assertStringNotContainsString('- a6', $output);
+    }
+
+    public function testControlBytesInPayloadAreStrippedFromOutput(): void
+    {
+        $renderer = new CustomAppsRenderer();
+        $state = new DeviceDomainState(true, [
+            'apps' => ["sto\x1bXcks", ['name' => "age\x1bXnda"]],
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringNotContainsString("\x1b", $output);
+    }
+}

--- a/tests/Tui/Dashboard/Renderer/IconsRendererTest.php
+++ b/tests/Tui/Dashboard/Renderer/IconsRendererTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Dashboard\Renderer;
+
+use App\Tui\Dashboard\Renderer\IconsRenderer;
+use App\Tui\DeviceState\DeviceDomainState;
+use PHPUnit\Framework\TestCase;
+
+final class IconsRendererTest extends TestCase
+{
+    public function testHasDataFalseReturnsNoData(): void
+    {
+        $renderer = new IconsRenderer();
+        $state = new DeviceDomainState(false, null);
+
+        self::assertSame('no data', $renderer->render($state));
+    }
+
+    public function testEmptyIconsArrayReturnsNoData(): void
+    {
+        $renderer = new IconsRenderer();
+        $state = new DeviceDomainState(true, ['icons' => []]);
+
+        self::assertSame('no data', $renderer->render($state));
+    }
+
+    public function testListOfStringsRendersCountAndNames(): void
+    {
+        $renderer = new IconsRenderer();
+        $state = new DeviceDomainState(true, [
+            'icons' => ['weather', 'clock', 'mail'],
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringContainsString('Count: 3', $output);
+        self::assertStringContainsString('- weather', $output);
+        self::assertStringContainsString('- clock', $output);
+        self::assertStringContainsString('- mail', $output);
+    }
+
+    public function testListOfObjectsRendersCountAndNames(): void
+    {
+        $renderer = new IconsRenderer();
+        $state = new DeviceDomainState(true, [
+            'icons' => [
+                ['name' => 'weather'],
+                ['name' => 'clock'],
+            ],
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringContainsString('Count: 2', $output);
+        self::assertStringContainsString('- weather', $output);
+        self::assertStringContainsString('- clock', $output);
+    }
+
+    public function testNameListIsTruncatedToFive(): void
+    {
+        $renderer = new IconsRenderer();
+        $state = new DeviceDomainState(true, [
+            'icons' => ['i1', 'i2', 'i3', 'i4', 'i5', 'i6', 'i7'],
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringContainsString('Count: 7', $output);
+        self::assertStringContainsString('- i1', $output);
+        self::assertStringContainsString('- i5', $output);
+        self::assertStringNotContainsString('- i6', $output);
+        self::assertStringNotContainsString('- i7', $output);
+    }
+
+    public function testControlBytesInPayloadAreStrippedFromOutput(): void
+    {
+        $renderer = new IconsRenderer();
+        $state = new DeviceDomainState(true, [
+            'icons' => ["wea\x1bXther", ['name' => "clo\x1bXck"]],
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringNotContainsString("\x1b", $output);
+    }
+}

--- a/tests/Tui/Dashboard/Renderer/IndicatorsRendererTest.php
+++ b/tests/Tui/Dashboard/Renderer/IndicatorsRendererTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Dashboard\Renderer;
+
+use App\Tui\Dashboard\Renderer\IndicatorsRenderer;
+use App\Tui\DeviceState\DeviceDomainState;
+use PHPUnit\Framework\TestCase;
+
+final class IndicatorsRendererTest extends TestCase
+{
+    public function testHasDataFalseReturnsNoData(): void
+    {
+        $renderer = new IndicatorsRenderer();
+        $state = new DeviceDomainState(false, null);
+
+        self::assertSame('no data', $renderer->render($state));
+    }
+
+    public function testAllSlotsNullRendersDashPerSlot(): void
+    {
+        $renderer = new IndicatorsRenderer();
+        $state = new DeviceDomainState(true, [
+            'slot1' => null,
+            'slot2' => null,
+            'slot3' => null,
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertSame("slot1: -\nslot2: -\nslot3: -", $output);
+    }
+
+    public function testOneSlotSetRendersLabelAndDashesForOthers(): void
+    {
+        $renderer = new IndicatorsRenderer();
+        $state = new DeviceDomainState(true, [
+            'slot1' => null,
+            'slot2' => ['label' => 'alarm'],
+            'slot3' => null,
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertSame("slot1: -\nslot2: alarm\nslot3: -", $output);
+    }
+
+    public function testStringSlotIsRenderedDirectly(): void
+    {
+        $renderer = new IndicatorsRenderer();
+        $state = new DeviceDomainState(true, [
+            'slot1' => 'battery',
+            'slot2' => null,
+            'slot3' => null,
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertSame("slot1: battery\nslot2: -\nslot3: -", $output);
+    }
+
+    public function testControlBytesInPayloadAreStrippedFromOutput(): void
+    {
+        $renderer = new IndicatorsRenderer();
+        $state = new DeviceDomainState(true, [
+            'slot1' => "bat\x1bXtery",
+            'slot2' => ['label' => "ala\x1bXrm"],
+            'slot3' => null,
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringNotContainsString("\x1b", $output);
+    }
+}

--- a/tests/Tui/Dashboard/Renderer/NotificationsRendererTest.php
+++ b/tests/Tui/Dashboard/Renderer/NotificationsRendererTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Dashboard\Renderer;
+
+use App\Tui\Dashboard\Renderer\NotificationsRenderer;
+use App\Tui\DeviceState\DeviceDomainState;
+use PHPUnit\Framework\TestCase;
+
+final class NotificationsRendererTest extends TestCase
+{
+    public function testHasDataFalseReturnsNoData(): void
+    {
+        $renderer = new NotificationsRenderer();
+        $state = new DeviceDomainState(false, null);
+
+        self::assertSame('no data', $renderer->render($state));
+    }
+
+    public function testEmptyQueueReturnsNoData(): void
+    {
+        $renderer = new NotificationsRenderer();
+        $state = new DeviceDomainState(true, ['queue' => []]);
+
+        self::assertSame('no data', $renderer->render($state));
+    }
+
+    public function testQueueIsRenderedInOrderWithPriorityPrefix(): void
+    {
+        $renderer = new NotificationsRenderer();
+        $state = new DeviceDomainState(true, [
+            'queue' => [
+                ['priority' => 'high', 'text' => 'first'],
+                ['priority' => 'low', 'text' => 'second'],
+            ],
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringContainsString('[high] first', $output);
+        self::assertStringContainsString('[low] second', $output);
+        $highPosition = strpos($output, '[high]');
+        $lowPosition = strpos($output, '[low]');
+        self::assertNotFalse($highPosition);
+        self::assertNotFalse($lowPosition);
+        self::assertLessThan($lowPosition, $highPosition);
+    }
+
+    public function testFallsBackToNotificationsKeyForProdParity(): void
+    {
+        $renderer = new NotificationsRenderer();
+        $state = new DeviceDomainState(true, [
+            'notifications' => [
+                ['priority' => 'high', 'text' => 'alert'],
+            ],
+        ]);
+
+        self::assertSame('[high] alert', $renderer->render($state));
+    }
+
+    public function testQueueIsTruncatedToEightRows(): void
+    {
+        $renderer = new NotificationsRenderer();
+        $queue = [];
+        for ($index = 1; $index <= 10; ++$index) {
+            $queue[] = ['priority' => 'low', 'text' => 'msg'.$index];
+        }
+        $state = new DeviceDomainState(true, ['queue' => $queue]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringContainsString('msg1', $output);
+        self::assertStringContainsString('msg8', $output);
+        self::assertStringNotContainsString('msg9', $output);
+    }
+
+    public function testControlBytesInPayloadAreStrippedFromOutput(): void
+    {
+        $renderer = new NotificationsRenderer();
+        $state = new DeviceDomainState(true, [
+            'queue' => [
+                ['priority' => "hi\x1bXgh", 'text' => "ale\x1bXrt"],
+            ],
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringNotContainsString("\x1b", $output);
+    }
+}

--- a/tests/Tui/Dashboard/Renderer/TrackersRendererTest.php
+++ b/tests/Tui/Dashboard/Renderer/TrackersRendererTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Dashboard\Renderer;
+
+use App\Tui\Dashboard\Renderer\TrackersRenderer;
+use App\Tui\DeviceState\DeviceDomainState;
+use PHPUnit\Framework\TestCase;
+
+final class TrackersRendererTest extends TestCase
+{
+    public function testHasDataFalseReturnsNoData(): void
+    {
+        $renderer = new TrackersRenderer();
+        $state = new DeviceDomainState(false, null);
+
+        self::assertSame('no data', $renderer->render($state));
+    }
+
+    public function testEmptyTrackersArrayReturnsNoData(): void
+    {
+        $renderer = new TrackersRenderer();
+        $state = new DeviceDomainState(true, ['trackers' => []]);
+
+        self::assertSame('no data', $renderer->render($state));
+    }
+
+    public function testSingleTrackerRendersLabelValueRow(): void
+    {
+        $renderer = new TrackersRenderer();
+        $state = new DeviceDomainState(true, [
+            'trackers' => [
+                ['label' => 'BTC', 'value' => '42000'],
+            ],
+        ]);
+
+        self::assertSame('BTC: 42000', $renderer->render($state));
+    }
+
+    public function testMultipleTrackersAreRenderedOnSeparateLines(): void
+    {
+        $renderer = new TrackersRenderer();
+        $state = new DeviceDomainState(true, [
+            'trackers' => [
+                ['label' => 'BTC', 'value' => '42000'],
+                ['label' => 'ETH', 'value' => '3000'],
+                ['label' => 'DOGE', 'value' => '0.15'],
+            ],
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringContainsString('BTC: 42000', $output);
+        self::assertStringContainsString('ETH: 3000', $output);
+        self::assertStringContainsString('DOGE: 0.15', $output);
+        self::assertSame(3, substr_count($output, "\n") + 1);
+    }
+
+    public function testTrackerListIsTruncatedToEightRows(): void
+    {
+        $renderer = new TrackersRenderer();
+        $trackers = [];
+        for ($index = 1; $index <= 12; ++$index) {
+            $trackers[] = ['label' => 'T'.$index, 'value' => (string) $index];
+        }
+        $state = new DeviceDomainState(true, ['trackers' => $trackers]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringContainsString('T1: 1', $output);
+        self::assertStringContainsString('T8: 8', $output);
+        self::assertStringNotContainsString('T9: 9', $output);
+    }
+
+    public function testControlBytesInPayloadAreStrippedFromOutput(): void
+    {
+        $renderer = new TrackersRenderer();
+        $state = new DeviceDomainState(true, [
+            'trackers' => [
+                ['label' => "BT\x1bXC", 'value' => "42\x1bX000"],
+            ],
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringNotContainsString("\x1b", $output);
+    }
+}

--- a/tests/Tui/Dashboard/Renderer/WeatherRendererTest.php
+++ b/tests/Tui/Dashboard/Renderer/WeatherRendererTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Dashboard\Renderer;
+
+use App\Tui\Dashboard\Renderer\WeatherRenderer;
+use App\Tui\DeviceState\DeviceDomainState;
+use PHPUnit\Framework\TestCase;
+
+final class WeatherRendererTest extends TestCase
+{
+    public function testHasDataFalseReturnsNoData(): void
+    {
+        $renderer = new WeatherRenderer();
+        $state = new DeviceDomainState(false, null);
+
+        self::assertSame('no data', $renderer->render($state));
+    }
+
+    public function testHasDataTrueButNonArrayPayloadReturnsNoData(): void
+    {
+        $renderer = new WeatherRenderer();
+        $state = new DeviceDomainState(true, 'not an array');
+
+        self::assertSame('no data', $renderer->render($state));
+    }
+
+    public function testCurrentBlockRendersTemperatureAndCondition(): void
+    {
+        $renderer = new WeatherRenderer();
+        $state = new DeviceDomainState(true, [
+            'current' => ['tempC' => 21, 'condition' => 'partly cloudy'],
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringContainsString('21C', $output);
+        self::assertStringContainsString('partly cloudy', $output);
+    }
+
+    public function testForecastEntriesAreTruncatedToThree(): void
+    {
+        $renderer = new WeatherRenderer();
+        $state = new DeviceDomainState(true, [
+            'current' => ['tempC' => 18, 'condition' => 'sunny'],
+            'forecast' => [
+                ['day' => 'Mon', 'minC' => 10, 'maxC' => 20, 'condition' => 'sunny'],
+                ['day' => 'Tue', 'minC' => 11, 'maxC' => 21, 'condition' => 'clouds'],
+                ['day' => 'Wed', 'minC' => 12, 'maxC' => 22, 'condition' => 'rain'],
+                ['day' => 'Thu', 'minC' => 13, 'maxC' => 23, 'condition' => 'storm'],
+            ],
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringContainsString('Mon', $output);
+        self::assertStringContainsString('Tue', $output);
+        self::assertStringContainsString('Wed', $output);
+        self::assertStringNotContainsString('Thu', $output);
+        self::assertStringNotContainsString('storm', $output);
+    }
+
+    public function testControlBytesInPayloadAreStrippedFromOutput(): void
+    {
+        $renderer = new WeatherRenderer();
+        $state = new DeviceDomainState(true, [
+            'current' => ['tempC' => 21, 'condition' => "partly\x1bX cloudy"],
+        ]);
+
+        $output = $renderer->render($state);
+
+        self::assertStringNotContainsString("\x1b", $output);
+    }
+}


### PR DESCRIPTION
## Summary

Fills the multi-zone TUI content zone (#43) with six always-rendered, independently collapsible blocks — one per `AppDomain` (Weather, Trackers, Notifications, Custom Apps, Indicators, Icons). Each block shows an `[on]`/`[off]` indicator driven by `DeviceStateSource::getDomainState(...)->hasData`, an expand/collapse toggle on a single keypress (Up/Down or j/k to navigate, Enter/Space to toggle), and a per-domain readable renderer producing formatted text — never raw JSON. Wiring covers both `TuiMode::Dev` (with the previously-unwired `DevDeviceStateSource`) and `TuiMode::Prod` (existing source reused). The collapsible behavior relies solely on the public `symfony/tui` API (`ContainerWidget` + `Style::withHidden`).

## Ticket

Closes #44