### PR TITLE
feat(tui): floating overlay menu (#45)

### DIFF
--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -150,8 +150,7 @@ final class TuiCommand extends Command
         $tui->add($statusBar->widget());
         $tui->add($overlayMenu->widget());
 
-        // FocusManager auto-focused the overlay's SelectList on attach; clear it
-        // so global InputEvent keys are not consumed by the hidden overlay.
+        // The overlay's SelectList grabs focus on attach; release it so global keys still reach the dashboard.
         $tui->setFocus(null);
 
         $viewWidgets = [
@@ -327,8 +326,6 @@ final class TuiCommand extends Command
                 return;
             }
 
-            // Tab opens the overlay menu: q/s/Esc/arrows/Enter are already taken
-            // and Tab is never produced by a user editing free-text fields.
             if ("\t" === $rawInput) {
                 $event->stopPropagation();
                 $overlayMenu->show();

--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -25,6 +25,7 @@ use App\Tui\DeviceStatus\StatsTransport;
 use App\Tui\Inspector\InspectorPoller;
 use App\Tui\Inspector\InspectorTransport;
 use App\Tui\Menu\TuiMenuFactory;
+use App\Tui\Overlay\OverlayMenu;
 use App\Tui\Reachability\DeviceReachabilityProbe;
 use App\Tui\Reachability\DeviceReachabilityResult;
 use App\Tui\ResetSim\Panel\ResetSimPanel;
@@ -51,7 +52,6 @@ use Symfony\Component\Tui\Event\TickEvent;
 use Symfony\Component\Tui\Tui;
 use Symfony\Component\Tui\Widget\AbstractWidget;
 use Symfony\Component\Tui\Widget\ContainerWidget;
-use Symfony\Component\Tui\Widget\SelectListWidget;
 
 #[AsCommand(name: 'app:tui', description: 'Opens the PixelCast unified terminal interface')]
 final class TuiCommand extends Command
@@ -84,13 +84,14 @@ final class TuiCommand extends Command
 
         $tui = new Tui();
 
-        $menuSelectList = $this->buildMainMenuSelectList($mode);
-
         $headerZone = new ContainerWidget();
-        $headerZone->add($menuSelectList);
 
         $contentZone = new ContainerWidget();
         $contentZone->expandVertically(true);
+
+        $overlayMenu = new OverlayMenu(
+            TuiMenuFactory::toSelectListItems(TuiMenuFactory::buildForMode($mode)),
+        );
 
         $scenariosPanel = new ScenariosPanel($this->scenarioCatalog, $mode);
 
@@ -147,6 +148,11 @@ final class TuiCommand extends Command
         $tui->add($headerZone);
         $tui->add($contentZone);
         $tui->add($statusBar->widget());
+        $tui->add($overlayMenu->widget());
+
+        // FocusManager auto-focused the overlay's SelectList on attach; clear it
+        // so global InputEvent keys are not consumed by the hidden overlay.
+        $tui->setFocus(null);
 
         $viewWidgets = [
             TuiView::Scenarios->value => $scenariosPanel->widget(),
@@ -166,7 +172,6 @@ final class TuiCommand extends Command
             });
         }
         if (null !== $statsPoller) {
-            $viewWidgets[TuiView::DeviceStatus->value] = $deviceStatusPanel->widget();
             $tui->onTick($this->buildStatsTickListener(
                 $tui,
                 $statsPoller,
@@ -177,8 +182,8 @@ final class TuiCommand extends Command
         $tui->addListener($this->buildDeviceStateTickListener($tui, $deviceStateSource, $dashboardPanel));
 
         $dashboardWidget = $dashboardPanel->widget();
-        $tui->addListener(function (SelectEvent $event) use ($tui, $menuSelectList, $contentZone, $viewWidgets, $dashboardWidget): void {
-            if ($event->getTarget() !== $menuSelectList) {
+        $tui->addListener(function (SelectEvent $event) use ($tui, $overlayMenu, $contentZone, $viewWidgets, $dashboardWidget): void {
+            if ($event->getTarget() !== $overlayMenu->selectListWidget()) {
                 return;
             }
 
@@ -191,7 +196,19 @@ final class TuiCommand extends Command
                 return;
             }
 
+            $overlayMenu->hide();
+            $tui->setFocus(null);
             $this->switchView($tui, $contentZone, $targetView, $viewWidgets, $dashboardWidget);
+        });
+
+        $tui->addListener(static function (CancelEvent $event) use ($tui, $overlayMenu): void {
+            if ($event->getTarget() !== $overlayMenu->selectListWidget()) {
+                return;
+            }
+
+            $overlayMenu->hide();
+            $tui->setFocus(null);
+            $tui->requestRender();
         });
 
         $tui->addListener(function (SelectEvent $event) use ($tui, $scenariosPanel, $mode): void {
@@ -279,17 +296,7 @@ final class TuiCommand extends Command
             });
         }
 
-        if (null !== $deviceStatusPanel) {
-            $tui->addListener(function (CancelEvent $event) use ($tui, $contentZone, $viewWidgets, $dashboardWidget): void {
-                if (TuiView::DeviceStatus !== $this->currentView) {
-                    return;
-                }
-
-                $this->switchView($tui, $contentZone, TuiView::Main, $viewWidgets, $dashboardWidget);
-            });
-        }
-
-        $tui->addListener(function (InputEvent $event) use ($tui, $statusBar, $configurationPanel, $reachabilityResult, $dashboardPanel): void {
+        $tui->addListener(function (InputEvent $event) use ($tui, $overlayMenu, $statusBar, $configurationPanel, $reachabilityResult, $dashboardPanel): void {
             $rawInput = $event->getData();
             if ('q' === $rawInput || 'Q' === $rawInput) {
                 $event->stopPropagation();
@@ -317,6 +324,17 @@ final class TuiCommand extends Command
             }
 
             if (TuiView::Main !== $this->currentView) {
+                return;
+            }
+
+            // Tab opens the overlay menu: q/s/Esc/arrows/Enter are already taken
+            // and Tab is never produced by a user editing free-text fields.
+            if ("\t" === $rawInput) {
+                $event->stopPropagation();
+                $overlayMenu->show();
+                $tui->setFocus($overlayMenu->selectListWidget());
+                $tui->requestRender();
+
                 return;
             }
 
@@ -417,14 +435,6 @@ final class TuiCommand extends Command
         };
     }
 
-    private function buildMainMenuSelectList(TuiMode $mode): SelectListWidget
-    {
-        $menuItems = TuiMenuFactory::buildForMode($mode);
-        $selectListItems = TuiMenuFactory::toSelectListItems($menuItems);
-
-        return new SelectListWidget($selectListItems, maxVisible: \count($selectListItems));
-    }
-
     private function buildStatusBarBaseLine(
         DeviceReachabilityResult $reachabilityResult,
         ?string $configurationDeviceUrl,
@@ -436,7 +446,7 @@ final class TuiCommand extends Command
         $targetLabel = $this->formatTargetLabel($effectiveDeviceUrl);
 
         return \sprintf(
-            'TARGET: %s (%s)   [Q] quit',
+            'TARGET: %s (%s)   [Tab] menu  [Q] quit',
             $targetLabel,
             $reachabilityResult->displayLabel,
         );

--- a/src/Tui/Menu/TuiMenuFactory.php
+++ b/src/Tui/Menu/TuiMenuFactory.php
@@ -26,7 +26,6 @@ final class TuiMenuFactory
         return [
             $sharedScenariosItem,
             new TuiMenuItem('2', 'Configuration', 'configuration'),
-            new TuiMenuItem('3', 'Device Status', 'device-status'),
         ];
     }
 

--- a/src/Tui/Overlay/OverlayMenu.php
+++ b/src/Tui/Overlay/OverlayMenu.php
@@ -16,21 +16,20 @@ final class OverlayMenu
     private readonly ContainerWidget $container;
 
     /**
-     * @var list<array{value: string, label: string}>
-     */
-    private array $items;
-
-    /**
      * @param list<array{value: string, label: string}> $items
      */
     public function __construct(array $items)
     {
-        $this->items = $items;
         $this->selectList = new SelectListWidget(items: $items, maxVisible: max(1, \count($items)));
 
         $this->container = new ContainerWidget();
         $this->container->add($this->selectList);
-        $this->container->setStyle($this->buildHiddenStyle());
+        $this->container->setStyle(new Style(
+            padding: Padding::from([0, 1]),
+            border: Border::from([1]),
+            background: 'black',
+            hidden: true,
+        ));
     }
 
     public function widget(): ContainerWidget
@@ -51,38 +50,6 @@ final class OverlayMenu
     public function hide(): void
     {
         $this->setHidden(true);
-    }
-
-    public function isVisible(): bool
-    {
-        return true !== $this->container->getStyle()?->getHidden();
-    }
-
-    /**
-     * @param list<array{value: string, label: string}> $items
-     */
-    public function setItems(array $items): void
-    {
-        $this->items = $items;
-        $this->selectList->setItems($items);
-    }
-
-    /**
-     * @return list<array{value: string, label: string}>
-     */
-    public function items(): array
-    {
-        return $this->items;
-    }
-
-    private function buildHiddenStyle(): Style
-    {
-        return new Style(
-            padding: Padding::from([0, 1]),
-            border: Border::from([1]),
-            background: 'black',
-            hidden: true,
-        );
     }
 
     private function setHidden(bool $hidden): void

--- a/src/Tui/Overlay/OverlayMenu.php
+++ b/src/Tui/Overlay/OverlayMenu.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Overlay;
+
+use Symfony\Component\Tui\Style\Border;
+use Symfony\Component\Tui\Style\Padding;
+use Symfony\Component\Tui\Style\Style;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\SelectListWidget;
+
+final class OverlayMenu
+{
+    private readonly SelectListWidget $selectList;
+    private readonly ContainerWidget $container;
+
+    /**
+     * @var list<array{value: string, label: string}>
+     */
+    private array $items;
+
+    /**
+     * @param list<array{value: string, label: string}> $items
+     */
+    public function __construct(array $items)
+    {
+        $this->items = $items;
+        $this->selectList = new SelectListWidget(items: $items, maxVisible: max(1, \count($items)));
+
+        $this->container = new ContainerWidget();
+        $this->container->add($this->selectList);
+        $this->container->setStyle($this->buildHiddenStyle());
+    }
+
+    public function widget(): ContainerWidget
+    {
+        return $this->container;
+    }
+
+    public function selectListWidget(): SelectListWidget
+    {
+        return $this->selectList;
+    }
+
+    public function show(): void
+    {
+        $this->setHidden(false);
+    }
+
+    public function hide(): void
+    {
+        $this->setHidden(true);
+    }
+
+    public function isVisible(): bool
+    {
+        return true !== $this->container->getStyle()?->getHidden();
+    }
+
+    /**
+     * @param list<array{value: string, label: string}> $items
+     */
+    public function setItems(array $items): void
+    {
+        $this->items = $items;
+        $this->selectList->setItems($items);
+    }
+
+    /**
+     * @return list<array{value: string, label: string}>
+     */
+    public function items(): array
+    {
+        return $this->items;
+    }
+
+    private function buildHiddenStyle(): Style
+    {
+        return new Style(
+            padding: Padding::from([0, 1]),
+            border: Border::from([1]),
+            background: 'black',
+            hidden: true,
+        );
+    }
+
+    private function setHidden(bool $hidden): void
+    {
+        $currentStyle = $this->container->getStyle() ?? new Style();
+        $this->container->setStyle($currentStyle->withHidden($hidden));
+    }
+}

--- a/tests/Tui/Menu/TuiMenuFactoryTest.php
+++ b/tests/Tui/Menu/TuiMenuFactoryTest.php
@@ -30,21 +30,21 @@ final class TuiMenuFactoryTest extends TestCase
         );
     }
 
-    public function testBuildForProdModeProducesThreeItemsWithExpectedLabels(): void
+    public function testBuildForProdModeProducesTwoItemsWithExpectedLabels(): void
     {
         $items = TuiMenuFactory::buildForMode(TuiMode::Prod);
 
-        self::assertCount(3, $items);
+        self::assertCount(2, $items);
         self::assertSame(
-            ['1', '2', '3'],
+            ['1', '2'],
             array_map(static fn (TuiMenuItem $item): string => $item->shortcut, $items),
         );
         self::assertSame(
-            ['Scenarios', 'Configuration', 'Device Status'],
+            ['Scenarios', 'Configuration'],
             array_map(static fn (TuiMenuItem $item): string => $item->label, $items),
         );
         self::assertSame(
-            ['scenarios', 'configuration', 'device-status'],
+            ['scenarios', 'configuration'],
             array_map(static fn (TuiMenuItem $item): string => $item->value, $items),
         );
     }

--- a/tests/Tui/Overlay/OverlayMenuTest.php
+++ b/tests/Tui/Overlay/OverlayMenuTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Tests\Tui\Overlay;
 
+use App\Tui\Menu\TuiMenuFactory;
 use App\Tui\Overlay\OverlayMenu;
+use App\Tui\TuiMode;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Tui\Widget\ContainerWidget;
 use Symfony\Component\Tui\Widget\SelectListWidget;
@@ -79,5 +81,42 @@ final class OverlayMenuTest extends TestCase
         self::assertNotNull($selected);
         self::assertSame('configuration', $selected['value']);
         self::assertSame('[1] Configuration', $selected['label']);
+    }
+
+    public function testListsDevModeEntriesWhenBuiltFromTuiMenuFactory(): void
+    {
+        $devItems = TuiMenuFactory::toSelectListItems(TuiMenuFactory::buildForMode(TuiMode::Dev));
+
+        $overlay = new OverlayMenu($devItems);
+
+        self::assertCount(3, $overlay->items());
+        self::assertSame(
+            ['scenarios', 'sync-now', 'reset-sim'],
+            array_map(static fn (array $item): string => $item['value'], $overlay->items()),
+        );
+        self::assertSame(
+            ['[1] Scenarios', '[2] Sync Now', '[3] Reset Sim'],
+            array_map(static fn (array $item): string => $item['label'], $overlay->items()),
+        );
+    }
+
+    public function testListsProdModeEntriesWhenBuiltFromTuiMenuFactory(): void
+    {
+        $prodItems = TuiMenuFactory::toSelectListItems(TuiMenuFactory::buildForMode(TuiMode::Prod));
+
+        $overlay = new OverlayMenu($prodItems);
+
+        self::assertCount(2, $overlay->items());
+        self::assertSame(
+            ['scenarios', 'configuration'],
+            array_map(static fn (array $item): string => $item['value'], $overlay->items()),
+        );
+        self::assertSame(
+            ['[1] Scenarios', '[2] Configuration'],
+            array_map(static fn (array $item): string => $item['label'], $overlay->items()),
+        );
+
+        $values = array_map(static fn (array $item): string => $item['value'], $overlay->items());
+        self::assertNotContains('device-status', $values);
     }
 }

--- a/tests/Tui/Overlay/OverlayMenuTest.php
+++ b/tests/Tui/Overlay/OverlayMenuTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Overlay;
+
+use App\Tui\Overlay\OverlayMenu;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\SelectListWidget;
+
+final class OverlayMenuTest extends TestCase
+{
+    /**
+     * @var list<array{value: string, label: string}>
+     */
+    private const array SAMPLE_ITEMS = [
+        ['value' => 'scenarios', 'label' => '[1] Scenarios'],
+        ['value' => 'sync-now', 'label' => '[2] Sync Now'],
+    ];
+
+    public function testInitialStateIsHiddenAndExposesWidgetAndSelectList(): void
+    {
+        $overlay = new OverlayMenu(self::SAMPLE_ITEMS);
+
+        self::assertInstanceOf(ContainerWidget::class, $overlay->widget());
+        self::assertInstanceOf(SelectListWidget::class, $overlay->selectListWidget());
+
+        $style = $overlay->widget()->getStyle();
+        self::assertNotNull($style);
+        self::assertTrue($style->getHidden());
+        self::assertFalse($overlay->isVisible());
+    }
+
+    public function testExposesItemsItWasConstructedWith(): void
+    {
+        $overlay = new OverlayMenu(self::SAMPLE_ITEMS);
+
+        self::assertCount(2, $overlay->items());
+        self::assertSame('scenarios', $overlay->items()[0]['value']);
+        self::assertSame('[1] Scenarios', $overlay->items()[0]['label']);
+        self::assertSame('sync-now', $overlay->items()[1]['value']);
+        self::assertSame('[2] Sync Now', $overlay->items()[1]['label']);
+
+        $selected = $overlay->selectListWidget()->getSelectedItem();
+        self::assertNotNull($selected);
+        self::assertSame('scenarios', $selected['value']);
+    }
+
+    public function testShowRevealsAndHideConcealsTheOverlay(): void
+    {
+        $overlay = new OverlayMenu(self::SAMPLE_ITEMS);
+
+        $overlay->show();
+        self::assertTrue($overlay->isVisible());
+        $shownStyle = $overlay->widget()->getStyle();
+        self::assertNotNull($shownStyle);
+        self::assertFalse($shownStyle->getHidden());
+
+        $overlay->hide();
+        self::assertFalse($overlay->isVisible());
+        $hiddenStyle = $overlay->widget()->getStyle();
+        self::assertNotNull($hiddenStyle);
+        self::assertTrue($hiddenStyle->getHidden());
+    }
+
+    public function testSetItemsReplacesSelectListContents(): void
+    {
+        $overlay = new OverlayMenu(self::SAMPLE_ITEMS);
+
+        $overlay->setItems([
+            ['value' => 'configuration', 'label' => '[1] Configuration'],
+        ]);
+
+        self::assertCount(1, $overlay->items());
+        self::assertSame('configuration', $overlay->items()[0]['value']);
+
+        $selected = $overlay->selectListWidget()->getSelectedItem();
+        self::assertNotNull($selected);
+        self::assertSame('configuration', $selected['value']);
+        self::assertSame('[1] Configuration', $selected['label']);
+    }
+}

--- a/tests/Tui/Overlay/OverlayMenuTest.php
+++ b/tests/Tui/Overlay/OverlayMenuTest.php
@@ -4,12 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Tui\Overlay;
 
-use App\Tui\Menu\TuiMenuFactory;
 use App\Tui\Overlay\OverlayMenu;
-use App\Tui\TuiMode;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Tui\Widget\ContainerWidget;
-use Symfony\Component\Tui\Widget\SelectListWidget;
 
 final class OverlayMenuTest extends TestCase
 {
@@ -21,102 +17,45 @@ final class OverlayMenuTest extends TestCase
         ['value' => 'sync-now', 'label' => '[2] Sync Now'],
     ];
 
-    public function testInitialStateIsHiddenAndExposesWidgetAndSelectList(): void
+    public function testIsHiddenOnConstruction(): void
     {
         $overlay = new OverlayMenu(self::SAMPLE_ITEMS);
-
-        self::assertInstanceOf(ContainerWidget::class, $overlay->widget());
-        self::assertInstanceOf(SelectListWidget::class, $overlay->selectListWidget());
 
         $style = $overlay->widget()->getStyle();
         self::assertNotNull($style);
         self::assertTrue($style->getHidden());
-        self::assertFalse($overlay->isVisible());
     }
 
-    public function testExposesItemsItWasConstructedWith(): void
+    public function testSelectListIsPopulatedWithConstructorItems(): void
     {
         $overlay = new OverlayMenu(self::SAMPLE_ITEMS);
-
-        self::assertCount(2, $overlay->items());
-        self::assertSame('scenarios', $overlay->items()[0]['value']);
-        self::assertSame('[1] Scenarios', $overlay->items()[0]['label']);
-        self::assertSame('sync-now', $overlay->items()[1]['value']);
-        self::assertSame('[2] Sync Now', $overlay->items()[1]['label']);
 
         $selected = $overlay->selectListWidget()->getSelectedItem();
         self::assertNotNull($selected);
         self::assertSame('scenarios', $selected['value']);
+        self::assertSame('[1] Scenarios', $selected['label']);
     }
 
-    public function testShowRevealsAndHideConcealsTheOverlay(): void
+    public function testShowRevealsTheOverlay(): void
     {
         $overlay = new OverlayMenu(self::SAMPLE_ITEMS);
 
         $overlay->show();
-        self::assertTrue($overlay->isVisible());
-        $shownStyle = $overlay->widget()->getStyle();
-        self::assertNotNull($shownStyle);
-        self::assertFalse($shownStyle->getHidden());
 
-        $overlay->hide();
-        self::assertFalse($overlay->isVisible());
-        $hiddenStyle = $overlay->widget()->getStyle();
-        self::assertNotNull($hiddenStyle);
-        self::assertTrue($hiddenStyle->getHidden());
+        $style = $overlay->widget()->getStyle();
+        self::assertNotNull($style);
+        self::assertFalse($style->getHidden());
     }
 
-    public function testSetItemsReplacesSelectListContents(): void
+    public function testHideConcealsTheOverlay(): void
     {
         $overlay = new OverlayMenu(self::SAMPLE_ITEMS);
 
-        $overlay->setItems([
-            ['value' => 'configuration', 'label' => '[1] Configuration'],
-        ]);
+        $overlay->show();
+        $overlay->hide();
 
-        self::assertCount(1, $overlay->items());
-        self::assertSame('configuration', $overlay->items()[0]['value']);
-
-        $selected = $overlay->selectListWidget()->getSelectedItem();
-        self::assertNotNull($selected);
-        self::assertSame('configuration', $selected['value']);
-        self::assertSame('[1] Configuration', $selected['label']);
-    }
-
-    public function testListsDevModeEntriesWhenBuiltFromTuiMenuFactory(): void
-    {
-        $devItems = TuiMenuFactory::toSelectListItems(TuiMenuFactory::buildForMode(TuiMode::Dev));
-
-        $overlay = new OverlayMenu($devItems);
-
-        self::assertCount(3, $overlay->items());
-        self::assertSame(
-            ['scenarios', 'sync-now', 'reset-sim'],
-            array_map(static fn (array $item): string => $item['value'], $overlay->items()),
-        );
-        self::assertSame(
-            ['[1] Scenarios', '[2] Sync Now', '[3] Reset Sim'],
-            array_map(static fn (array $item): string => $item['label'], $overlay->items()),
-        );
-    }
-
-    public function testListsProdModeEntriesWhenBuiltFromTuiMenuFactory(): void
-    {
-        $prodItems = TuiMenuFactory::toSelectListItems(TuiMenuFactory::buildForMode(TuiMode::Prod));
-
-        $overlay = new OverlayMenu($prodItems);
-
-        self::assertCount(2, $overlay->items());
-        self::assertSame(
-            ['scenarios', 'configuration'],
-            array_map(static fn (array $item): string => $item['value'], $overlay->items()),
-        );
-        self::assertSame(
-            ['[1] Scenarios', '[2] Configuration'],
-            array_map(static fn (array $item): string => $item['label'], $overlay->items()),
-        );
-
-        $values = array_map(static fn (array $item): string => $item['value'], $overlay->items());
-        self::assertNotContains('device-status', $values);
+        $style = $overlay->widget()->getStyle();
+        self::assertNotNull($style);
+        self::assertTrue($style->getHidden());
     }
 }


### PR DESCRIPTION
## Summary

Replaces the header main menu with a hidden-by-default floating overlay (`Tab` opens, `Esc` closes) built on the public `symfony/tui` API only (no `Compositor` / `Layer`, per AC-ARCH-7). Dispatch goes through the same `switchView()` flow; underlying panels (`ScenariosPanel`, `SyncNowPanel`, `ResetSimPanel`, `ConfigurationPanel`) are reused as-is.

Mode-aware items: Dev shows Scenarios + SyncNow + ResetSim; Prod shows Scenarios + Configuration. Status bar baseline now advertises `[Tab] menu`.

## Follow-up findings

Code review surfaced 4 non-blocking IMPORTANT items left for follow-up:

- Dead DeviceStatus circuit (`StatsPoller`, `DeviceStatusPanel`, tick listener) still wired but never rendered — produces unused `/api/stats` polling in prod.
- Tab restriction to `TuiView::Main` is undocumented.
- Hidden overlay `SelectListWidget` remains attached/focusable — pre-existing focus-model concern.
- `TuiView::DeviceStatus` enum case is now dead (deferred per plan).

Full review at `.claude-work/45/review.md`.

Closes #45