### PR TITLE
feat(tui): visual polish for dashboard (#46)

### DIFF
--- a/src/Command/TuiCommand.php
+++ b/src/Command/TuiCommand.php
@@ -443,7 +443,7 @@ final class TuiCommand extends Command
         $targetLabel = $this->formatTargetLabel($effectiveDeviceUrl);
 
         return \sprintf(
-            'TARGET: %s (%s)   [Tab] menu  [Q] quit',
+            'TARGET: %s (%s) │ [Tab] menu │ [Q] quit',
             $targetLabel,
             $reachabilityResult->displayLabel,
         );

--- a/src/Domain/AppDomain.php
+++ b/src/Domain/AppDomain.php
@@ -9,7 +9,7 @@ enum AppDomain: string
     case Weather = 'weather';
     case Trackers = 'trackers';
     case Notifications = 'notifications';
-    case CustomApps = 'customApps';
     case Indicators = 'indicators';
     case Icons = 'icons';
+    case CustomApps = 'customApps';
 }

--- a/src/Tui/Dashboard/CollapsibleBlock.php
+++ b/src/Tui/Dashboard/CollapsibleBlock.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tui\Dashboard;
 
+use App\Tui\Style\Palette;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Widget\ContainerWidget;
 use Symfony\Component\Tui\Widget\TextWidget;
@@ -15,18 +16,25 @@ final class CollapsibleBlock
     private const string SELECTION_PREFIX_SELECTED = '> ';
     private const string SELECTION_PREFIX_UNSELECTED = '  ';
     private const string EMPTY_BODY_TEXT = 'no data';
+    private const array TOP_ONLY_BORDER = [1, 0, 0, 0];
+    private const array FULL_BORDER = [1, 1, 1, 1];
 
     private readonly TextWidget $headerWidget;
     private readonly TextWidget $bodyTextWidget;
     private readonly ContainerWidget $bodyContainer;
     private readonly ContainerWidget $outerContainer;
+    private readonly Palette $palette;
 
     private bool $expanded = false;
     private bool $hasData = false;
     private bool $selected = false;
+    private string $summary = '';
 
-    public function __construct(private readonly string $title)
-    {
+    public function __construct(
+        private readonly string $title,
+        ?Palette $palette = null,
+    ) {
+        $this->palette = $palette ?? new Palette();
         $this->headerWidget = new TextWidget($this->renderHeaderLine());
         $this->bodyTextWidget = new TextWidget(self::EMPTY_BODY_TEXT);
 
@@ -37,6 +45,8 @@ final class CollapsibleBlock
         $this->outerContainer = new ContainerWidget();
         $this->outerContainer->add($this->headerWidget);
         $this->outerContainer->add($this->bodyContainer);
+
+        $this->applyOnOffStyle();
     }
 
     public function widget(): ContainerWidget
@@ -73,20 +83,42 @@ final class CollapsibleBlock
 
     public function setState(bool $hasData, string $bodyText): void
     {
+        $hasDataChanged = $this->hasData !== $hasData;
         $this->hasData = $hasData;
         $this->bodyTextWidget->setText($bodyText);
         $this->headerWidget->setText($this->renderHeaderLine());
+
+        if ($hasDataChanged) {
+            $this->applyOnOffStyle();
+        }
     }
 
     public function setSelected(bool $selected): void
     {
         $this->selected = $selected;
         $this->headerWidget->setText($this->renderHeaderLine());
+        $this->applyOnOffStyle();
+    }
+
+    public function setSummary(string $summary): void
+    {
+        $this->summary = $summary;
+        $this->headerWidget->setText($this->renderHeaderLine());
+    }
+
+    public function summary(): string
+    {
+        return $this->summary;
     }
 
     public function headerText(): string
     {
         return $this->headerWidget->getText();
+    }
+
+    public function headerStyle(): ?Style
+    {
+        return $this->headerWidget->getStyle();
     }
 
     public function bodyText(): string
@@ -103,13 +135,68 @@ final class CollapsibleBlock
     {
         $selectionPrefix = $this->selected ? self::SELECTION_PREFIX_SELECTED : self::SELECTION_PREFIX_UNSELECTED;
         $stateMarker = $this->hasData ? self::STATE_MARKER_ON : self::STATE_MARKER_OFF;
+        $headerLine = $selectionPrefix.$this->title.' '.$stateMarker;
 
-        return $selectionPrefix.$this->title.' '.$stateMarker;
+        if (!$this->expanded && '' !== $this->summary) {
+            $headerLine .= ' '.$this->summary;
+        }
+
+        return $headerLine;
     }
 
     private function applyExpansionStyle(): void
     {
         $currentStyle = $this->bodyContainer->getStyle() ?? new Style();
         $this->bodyContainer->setStyle($currentStyle->withHidden(!$this->expanded));
+        $this->headerWidget->setText($this->renderHeaderLine());
+    }
+
+    private function applyOnOffStyle(): void
+    {
+        if ($this->hasData) {
+            $this->applyOnStyle();
+
+            return;
+        }
+
+        $this->applyOffStyle();
+    }
+
+    private function applyOnStyle(): void
+    {
+        $this->headerWidget->setStyle(
+            new Style()
+                ->withBold(true)
+                ->withColor($this->palette->headerText),
+        );
+        $this->outerContainer->setStyle(
+            new Style()->withBorder(
+                $this->borderSides(),
+                color: $this->palette->borderAccent,
+            ),
+        );
+    }
+
+    private function applyOffStyle(): void
+    {
+        $this->headerWidget->setStyle(
+            new Style()
+                ->withDim(true)
+                ->withColor($this->palette->dimText),
+        );
+        $this->outerContainer->setStyle(
+            new Style()->withBorder(
+                $this->borderSides(),
+                color: $this->palette->borderDim,
+            ),
+        );
+    }
+
+    /**
+     * @return array{int, int, int, int}
+     */
+    private function borderSides(): array
+    {
+        return $this->selected ? self::FULL_BORDER : self::TOP_ONLY_BORDER;
     }
 }

--- a/src/Tui/Dashboard/Panel/DashboardPanel.php
+++ b/src/Tui/Dashboard/Panel/DashboardPanel.php
@@ -14,6 +14,7 @@ use App\Tui\Dashboard\Renderer\NotificationsRenderer;
 use App\Tui\Dashboard\Renderer\TrackersRenderer;
 use App\Tui\Dashboard\Renderer\WeatherRenderer;
 use App\Tui\DeviceState\DeviceStateSource;
+use App\Tui\Style\Palette;
 use Symfony\Component\Tui\Widget\ContainerWidget;
 
 final class DashboardPanel
@@ -31,11 +32,12 @@ final class DashboardPanel
 
     private int $selectedBlockIndex = 0;
 
-    public function __construct()
+    public function __construct(?Palette $palette = null)
     {
+        $palette ??= new Palette();
         $blocks = [];
         foreach (AppDomain::cases() as $domain) {
-            $blocks[$domain->value] = new CollapsibleBlock(self::titleFor($domain));
+            $blocks[$domain->value] = new CollapsibleBlock(self::titleFor($domain), $palette);
         }
         $this->blocks = $blocks;
 
@@ -43,9 +45,9 @@ final class DashboardPanel
             AppDomain::Weather->value => new WeatherRenderer(),
             AppDomain::Trackers->value => new TrackersRenderer(),
             AppDomain::Notifications->value => new NotificationsRenderer(),
-            AppDomain::CustomApps->value => new CustomAppsRenderer(),
             AppDomain::Indicators->value => new IndicatorsRenderer(),
             AppDomain::Icons->value => new IconsRenderer(),
+            AppDomain::CustomApps->value => new CustomAppsRenderer(),
         ];
 
         $this->orderedDomains = AppDomain::cases();
@@ -68,8 +70,10 @@ final class DashboardPanel
     {
         foreach ($this->orderedDomains as $domain) {
             $state = $source->getDomainState($domain);
-            $body = $this->renderers[$domain->value]->render($state);
-            $this->blocks[$domain->value]->setState($state->hasData, $body);
+            $renderer = $this->renderers[$domain->value];
+            $block = $this->blocks[$domain->value];
+            $block->setState($state->hasData, $renderer->render($state));
+            $block->setSummary($renderer->summary($state));
         }
     }
 

--- a/src/Tui/Dashboard/Renderer/CustomAppsRenderer.php
+++ b/src/Tui/Dashboard/Renderer/CustomAppsRenderer.php
@@ -48,6 +48,27 @@ final class CustomAppsRenderer implements DomainRenderer
         return implode("\n", $lines);
     }
 
+    public function summary(DeviceDomainState $state): string
+    {
+        if (false === $state->hasData) {
+            return '';
+        }
+
+        $payload = $state->payload;
+        if (!\is_array($payload)) {
+            return '';
+        }
+
+        $apps = $payload['apps'] ?? null;
+        if (!\is_array($apps) || [] === $apps) {
+            return '';
+        }
+
+        $totalCount = \count($apps);
+
+        return $totalCount.' '.(1 === $totalCount ? 'app' : 'apps');
+    }
+
     private function extractAppName(mixed $app): ?string
     {
         if (\is_string($app)) {

--- a/src/Tui/Dashboard/Renderer/DomainRenderer.php
+++ b/src/Tui/Dashboard/Renderer/DomainRenderer.php
@@ -9,4 +9,6 @@ use App\Tui\DeviceState\DeviceDomainState;
 interface DomainRenderer
 {
     public function render(DeviceDomainState $state): string;
+
+    public function summary(DeviceDomainState $state): string;
 }

--- a/src/Tui/Dashboard/Renderer/IconsRenderer.php
+++ b/src/Tui/Dashboard/Renderer/IconsRenderer.php
@@ -48,6 +48,27 @@ final class IconsRenderer implements DomainRenderer
         return implode("\n", $lines);
     }
 
+    public function summary(DeviceDomainState $state): string
+    {
+        if (false === $state->hasData) {
+            return '';
+        }
+
+        $payload = $state->payload;
+        if (!\is_array($payload)) {
+            return '';
+        }
+
+        $icons = $payload['icons'] ?? null;
+        if (!\is_array($icons) || [] === $icons) {
+            return '';
+        }
+
+        $totalCount = \count($icons);
+
+        return $totalCount.' '.(1 === $totalCount ? 'icon' : 'icons');
+    }
+
     private function extractIconName(mixed $icon): ?string
     {
         if (\is_string($icon)) {

--- a/src/Tui/Dashboard/Renderer/IndicatorsRenderer.php
+++ b/src/Tui/Dashboard/Renderer/IndicatorsRenderer.php
@@ -34,6 +34,27 @@ final class IndicatorsRenderer implements DomainRenderer
         return implode("\n", $lines);
     }
 
+    public function summary(DeviceDomainState $state): string
+    {
+        if (false === $state->hasData) {
+            return '';
+        }
+
+        $payload = $state->payload;
+        if (!\is_array($payload)) {
+            return '';
+        }
+
+        $filled = 0;
+        foreach (self::SLOT_KEYS as $slotKey) {
+            if (self::EMPTY_SLOT_TEXT !== $this->formatSlotLabel($payload[$slotKey] ?? null)) {
+                ++$filled;
+            }
+        }
+
+        return $filled.'/'.\count(self::SLOT_KEYS).' slots';
+    }
+
     private function formatSlotLabel(mixed $slot): string
     {
         if (null === $slot) {

--- a/src/Tui/Dashboard/Renderer/NotificationsRenderer.php
+++ b/src/Tui/Dashboard/Renderer/NotificationsRenderer.php
@@ -12,6 +12,9 @@ final class NotificationsRenderer implements DomainRenderer
     private const string NO_DATA_TEXT = 'no data';
     private const int MAX_ROWS = 8;
 
+    /** @var array<string, int> */
+    private const array PRIORITY_RANK = ['low' => 0, 'normal' => 1, 'high' => 2];
+
     public function render(DeviceDomainState $state): string
     {
         if (false === $state->hasData) {
@@ -47,6 +50,58 @@ final class NotificationsRenderer implements DomainRenderer
         }
 
         return implode("\n", $lines);
+    }
+
+    public function summary(DeviceDomainState $state): string
+    {
+        if (false === $state->hasData) {
+            return '';
+        }
+
+        $payload = $state->payload;
+        if (!\is_array($payload)) {
+            return '';
+        }
+
+        $notifications = $this->extractNotifications($payload);
+        $renderableCount = 0;
+        $topPriority = null;
+        $topRank = null;
+        foreach ($notifications as $notification) {
+            if (null === $this->renderNotificationLine($notification)) {
+                continue;
+            }
+            ++$renderableCount;
+
+            if (!\is_array($notification)) {
+                continue;
+            }
+            $priority = $this->formatString($notification['priority'] ?? null);
+            if (null === $priority) {
+                continue;
+            }
+            $rank = self::PRIORITY_RANK[strtolower($priority)] ?? null;
+            if (null === $rank) {
+                if (null === $topPriority) {
+                    $topPriority = $priority;
+                }
+                continue;
+            }
+            if (null === $topRank || $rank > $topRank) {
+                $topRank = $rank;
+                $topPriority = $priority;
+            }
+        }
+
+        if (0 === $renderableCount) {
+            return '0 notifications';
+        }
+
+        if (null === $topPriority) {
+            return (string) $renderableCount;
+        }
+
+        return $renderableCount.' ('.$topPriority.')';
     }
 
     /**

--- a/src/Tui/Dashboard/Renderer/TrackersRenderer.php
+++ b/src/Tui/Dashboard/Renderer/TrackersRenderer.php
@@ -49,6 +49,32 @@ final class TrackersRenderer implements DomainRenderer
         return implode("\n", $lines);
     }
 
+    public function summary(DeviceDomainState $state): string
+    {
+        if (false === $state->hasData) {
+            return '';
+        }
+
+        $payload = $state->payload;
+        if (!\is_array($payload)) {
+            return '';
+        }
+
+        $trackers = $payload['trackers'] ?? null;
+        if (!\is_array($trackers)) {
+            return '';
+        }
+
+        $renderableCount = 0;
+        foreach ($trackers as $tracker) {
+            if (null !== $this->renderTrackerLine($tracker)) {
+                ++$renderableCount;
+            }
+        }
+
+        return $renderableCount.' '.(1 === $renderableCount ? 'tracker' : 'trackers');
+    }
+
     private function renderTrackerLine(mixed $tracker): ?string
     {
         if (!\is_array($tracker)) {

--- a/src/Tui/Dashboard/Renderer/WeatherRenderer.php
+++ b/src/Tui/Dashboard/Renderer/WeatherRenderer.php
@@ -41,6 +41,38 @@ final class WeatherRenderer implements DomainRenderer
         return implode("\n", $lines);
     }
 
+    public function summary(DeviceDomainState $state): string
+    {
+        if (false === $state->hasData) {
+            return '';
+        }
+
+        $payload = $state->payload;
+        if (!\is_array($payload)) {
+            return '';
+        }
+
+        $current = $payload['current'] ?? null;
+        if (!\is_array($current)) {
+            return '';
+        }
+
+        $temperature = $this->formatTemperature($current['tempC'] ?? null);
+        $condition = $this->formatString($current['condition'] ?? null);
+
+        if (null === $temperature && null === $condition) {
+            return '';
+        }
+        if (null === $condition) {
+            return $temperature;
+        }
+        if (null === $temperature) {
+            return $condition;
+        }
+
+        return $temperature.' '.$condition;
+    }
+
     private function renderCurrentLine(mixed $current): ?string
     {
         if (!\is_array($current)) {

--- a/src/Tui/Overlay/OverlayMenu.php
+++ b/src/Tui/Overlay/OverlayMenu.php
@@ -4,29 +4,54 @@ declare(strict_types=1);
 
 namespace App\Tui\Overlay;
 
+use App\Tui\Style\Palette;
 use Symfony\Component\Tui\Style\Border;
+use Symfony\Component\Tui\Style\BorderPattern;
 use Symfony\Component\Tui\Style\Padding;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Widget\ContainerWidget;
 use Symfony\Component\Tui\Widget\SelectListWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
 
 final class OverlayMenu
 {
+    private const string FOOTER_HINT = '[Esc] close';
+
     private readonly SelectListWidget $selectList;
+    private readonly TextWidget $titleWidget;
+    private readonly TextWidget $footerWidget;
     private readonly ContainerWidget $container;
 
     /**
      * @param list<array{value: string, label: string}> $items
      */
-    public function __construct(array $items)
+    public function __construct(array $items, string $title = 'Menu', ?Palette $palette = null)
     {
+        $palette ??= new Palette();
+
+        $this->titleWidget = new TextWidget($title);
+        $this->titleWidget->setStyle(
+            new Style()
+                ->withBold(true)
+                ->withColor($palette->accentText),
+        );
+
         $this->selectList = new SelectListWidget(items: $items, maxVisible: max(1, \count($items)));
 
+        $this->footerWidget = new TextWidget(self::FOOTER_HINT);
+        $this->footerWidget->setStyle(
+            new Style()
+                ->withDim(true)
+                ->withColor($palette->dimText),
+        );
+
         $this->container = new ContainerWidget();
+        $this->container->add($this->titleWidget);
         $this->container->add($this->selectList);
+        $this->container->add($this->footerWidget);
         $this->container->setStyle(new Style(
             padding: Padding::from([0, 1]),
-            border: Border::from([1]),
+            border: Border::from([1], pattern: BorderPattern::rounded(), color: $palette->borderAccent),
             background: 'black',
             hidden: true,
         ));

--- a/src/Tui/StatusBar/StatusBarWidget.php
+++ b/src/Tui/StatusBar/StatusBarWidget.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tui\StatusBar;
 
+use App\Tui\Style\Palette;
 use App\Tui\TuiMode;
 use Symfony\Component\Tui\Style\Direction;
 use Symfony\Component\Tui\Style\Style;
@@ -13,7 +14,7 @@ use Symfony\Component\Tui\Widget\TextWidget;
 final class StatusBarWidget
 {
     private const string UNSAVED_INDICATOR = 'UNSAVED CHANGES';
-    private const string SEPARATOR = '   ';
+    private const string SEPARATOR = ' │ ';
 
     private readonly ContainerWidget $container;
     private readonly TextWidget $chipWidget;
@@ -22,9 +23,9 @@ final class StatusBarWidget
     private string $baseLine = '';
     private bool $hasUnsavedChanges = false;
 
-    public function __construct(TuiMode $mode)
+    public function __construct(TuiMode $mode, ?Palette $palette = null)
     {
-        $this->chipStyle = $this->buildChipStyle($mode);
+        $this->chipStyle = $this->buildChipStyle($mode, $palette ?? new Palette());
         $this->chipWidget = new TextWidget(' '.$mode->displayLabel().' ');
         $this->chipWidget->setStyle($this->chipStyle);
 
@@ -86,11 +87,19 @@ final class StatusBarWidget
         $this->restLineWidget->setText($text);
     }
 
-    private function buildChipStyle(TuiMode $mode): Style
+    private function buildChipStyle(TuiMode $mode, Palette $palette): Style
     {
         return match ($mode) {
-            TuiMode::Dev => new Style(background: 'green', color: 'black', bold: true),
-            TuiMode::Prod => new Style(background: 'red', color: 'white', bold: true),
+            TuiMode::Dev => new Style(
+                background: $palette->devChipBackground,
+                color: $palette->devChipForeground,
+                bold: true,
+            ),
+            TuiMode::Prod => new Style(
+                background: $palette->prodChipBackground,
+                color: $palette->prodChipForeground,
+                bold: true,
+            ),
         };
     }
 }

--- a/src/Tui/Style/Palette.php
+++ b/src/Tui/Style/Palette.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tui\Style;
+
+final readonly class Palette
+{
+    public function __construct(
+        public string $headerText = 'cyan',
+        public string $devChipBackground = 'yellow',
+        public string $devChipForeground = 'black',
+        public string $prodChipBackground = 'red',
+        public string $prodChipForeground = 'white',
+        public string $borderDim = 'gray',
+        public string $borderAccent = 'green',
+        public string $dimText = 'gray',
+        public string $accentText = 'bright_white',
+    ) {
+    }
+}

--- a/tests/Domain/AppDomainTest.php
+++ b/tests/Domain/AppDomainTest.php
@@ -15,9 +15,9 @@ final class AppDomainTest extends TestCase
             'Weather' => 'weather',
             'Trackers' => 'trackers',
             'Notifications' => 'notifications',
-            'CustomApps' => 'customApps',
             'Indicators' => 'indicators',
             'Icons' => 'icons',
+            'CustomApps' => 'customApps',
         ];
 
         $actual = [];

--- a/tests/Tui/Dashboard/CollapsibleBlockTest.php
+++ b/tests/Tui/Dashboard/CollapsibleBlockTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Tests\Tui\Dashboard;
 
 use App\Tui\Dashboard\CollapsibleBlock;
+use App\Tui\Style\Palette;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Style\Color;
 
 final class CollapsibleBlockTest extends TestCase
 {
@@ -109,5 +111,102 @@ final class CollapsibleBlockTest extends TestCase
         $block->setState(true, 'body');
 
         self::assertSame('> Trackers [on]', $block->headerText());
+    }
+
+    public function testHeaderIncludesSummaryWhileCollapsed(): void
+    {
+        $block = new CollapsibleBlock('Icons');
+
+        $block->setSummary('5 icons');
+
+        self::assertStringEndsWith('5 icons', $block->headerText());
+    }
+
+    public function testHeaderHidesSummaryWhenExpanded(): void
+    {
+        $block = new CollapsibleBlock('Icons');
+        $block->setSummary('5 icons');
+
+        $block->expand();
+
+        self::assertStringNotContainsString('5 icons', $block->headerText());
+    }
+
+    public function testHeaderWidgetIsBoldWhenHasDataIsTrue(): void
+    {
+        $palette = new Palette();
+        $block = new CollapsibleBlock('Weather');
+
+        $block->setState(true, 'body');
+
+        $headerStyle = $block->headerStyle();
+        self::assertNotNull($headerStyle);
+        self::assertTrue($headerStyle->getBold());
+        $color = $headerStyle->getColor();
+        self::assertNotNull($color);
+        self::assertSame(Color::from($palette->headerText)->toHex(), $color->toHex());
+    }
+
+    public function testHeaderWidgetIsDimWhenHasDataIsFalse(): void
+    {
+        $palette = new Palette();
+        $block = new CollapsibleBlock('Weather');
+
+        $block->setState(false, 'no data');
+
+        $headerStyle = $block->headerStyle();
+        self::assertNotNull($headerStyle);
+        self::assertTrue($headerStyle->getDim());
+        $color = $headerStyle->getColor();
+        self::assertNotNull($color);
+        self::assertSame(Color::from($palette->dimText)->toHex(), $color->toHex());
+    }
+
+    public function testOuterContainerBorderUsesAccentColorWhenOn(): void
+    {
+        $palette = new Palette();
+        $block = new CollapsibleBlock('Weather');
+
+        $block->setState(true, 'body');
+
+        $border = $block->widget()->getStyle()?->getBorder();
+        self::assertNotNull($border);
+        $borderColor = $border->color;
+        self::assertNotNull($borderColor);
+        self::assertSame(Color::from($palette->borderAccent)->toHex(), $borderColor->toHex());
+    }
+
+    public function testOuterContainerBorderUsesDimColorWhenOff(): void
+    {
+        $palette = new Palette();
+        $block = new CollapsibleBlock('Weather');
+
+        $border = $block->widget()->getStyle()?->getBorder();
+        self::assertNotNull($border);
+        $borderColor = $border->color;
+        self::assertNotNull($borderColor);
+        self::assertSame(Color::from($palette->borderDim)->toHex(), $borderColor->toHex());
+    }
+
+    public function testSelectedBlockUsesFullBorderInsteadOfTopOnly(): void
+    {
+        $block = new CollapsibleBlock('Weather');
+        $block->setState(true, 'body');
+
+        $unselectedBorder = $block->widget()->getStyle()?->getBorder();
+        self::assertNotNull($unselectedBorder);
+        self::assertSame(1, $unselectedBorder->top);
+        self::assertSame(0, $unselectedBorder->right);
+        self::assertSame(0, $unselectedBorder->bottom);
+        self::assertSame(0, $unselectedBorder->left);
+
+        $block->setSelected(true);
+
+        $selectedBorder = $block->widget()->getStyle()?->getBorder();
+        self::assertNotNull($selectedBorder);
+        self::assertSame(1, $selectedBorder->top);
+        self::assertSame(1, $selectedBorder->right);
+        self::assertSame(1, $selectedBorder->bottom);
+        self::assertSame(1, $selectedBorder->left);
     }
 }

--- a/tests/Tui/Dashboard/Panel/DashboardPanelTest.php
+++ b/tests/Tui/Dashboard/Panel/DashboardPanelTest.php
@@ -134,6 +134,16 @@ final class DashboardPanelTest extends TestCase
         self::assertStringNotContainsString("\x1b", $weatherBodyText);
     }
 
+    public function testEnumCasesFollowCanonicalOrder(): void
+    {
+        $domainValues = array_map(static fn (AppDomain $domain) => $domain->value, AppDomain::cases());
+
+        self::assertSame(
+            ['weather', 'trackers', 'notifications', 'indicators', 'icons', 'customApps'],
+            $domainValues,
+        );
+    }
+
     public function testToggleSelectedRevealsOnlySelectedBlockBodyAndKeepsOthersHidden(): void
     {
         $statesByDomainValue = [

--- a/tests/Tui/Dashboard/Renderer/CustomAppsRendererTest.php
+++ b/tests/Tui/Dashboard/Renderer/CustomAppsRendererTest.php
@@ -84,4 +84,30 @@ final class CustomAppsRendererTest extends TestCase
 
         self::assertStringNotContainsString("\x1b", $output);
     }
+
+    public function testSummaryReturnsEmptyStringWhenStateHasNoData(): void
+    {
+        $renderer = new CustomAppsRenderer();
+        $state = new DeviceDomainState(false, null);
+
+        self::assertSame('', $renderer->summary($state));
+    }
+
+    public function testSummaryReturnsExpectedTextWithFullPayload(): void
+    {
+        $renderer = new CustomAppsRenderer();
+        $state = new DeviceDomainState(true, [
+            'apps' => ['stocks', 'agenda'],
+        ]);
+
+        self::assertSame('2 apps', $renderer->summary($state));
+    }
+
+    public function testSummaryHandlesPartialOrEmptyPayloadGracefully(): void
+    {
+        $renderer = new CustomAppsRenderer();
+        $state = new DeviceDomainState(true, ['apps' => []]);
+
+        self::assertSame('', $renderer->summary($state));
+    }
 }

--- a/tests/Tui/Dashboard/Renderer/IconsRendererTest.php
+++ b/tests/Tui/Dashboard/Renderer/IconsRendererTest.php
@@ -85,4 +85,30 @@ final class IconsRendererTest extends TestCase
 
         self::assertStringNotContainsString("\x1b", $output);
     }
+
+    public function testSummaryReturnsEmptyStringWhenStateHasNoData(): void
+    {
+        $renderer = new IconsRenderer();
+        $state = new DeviceDomainState(false, null);
+
+        self::assertSame('', $renderer->summary($state));
+    }
+
+    public function testSummaryReturnsExpectedTextWithFullPayload(): void
+    {
+        $renderer = new IconsRenderer();
+        $state = new DeviceDomainState(true, [
+            'icons' => ['weather', 'clock', 'mail', 'calendar', 'sport'],
+        ]);
+
+        self::assertSame('5 icons', $renderer->summary($state));
+    }
+
+    public function testSummaryHandlesPartialOrEmptyPayloadGracefully(): void
+    {
+        $renderer = new IconsRenderer();
+        $state = new DeviceDomainState(true, ['icons' => []]);
+
+        self::assertSame('', $renderer->summary($state));
+    }
 }

--- a/tests/Tui/Dashboard/Renderer/IndicatorsRendererTest.php
+++ b/tests/Tui/Dashboard/Renderer/IndicatorsRendererTest.php
@@ -73,4 +73,32 @@ final class IndicatorsRendererTest extends TestCase
 
         self::assertStringNotContainsString("\x1b", $output);
     }
+
+    public function testSummaryReturnsEmptyStringWhenStateHasNoData(): void
+    {
+        $renderer = new IndicatorsRenderer();
+        $state = new DeviceDomainState(false, null);
+
+        self::assertSame('', $renderer->summary($state));
+    }
+
+    public function testSummaryReturnsExpectedTextWithFullPayload(): void
+    {
+        $renderer = new IndicatorsRenderer();
+        $state = new DeviceDomainState(true, [
+            'slot1' => 'battery',
+            'slot2' => ['label' => 'alarm'],
+            'slot3' => null,
+        ]);
+
+        self::assertSame('2/3 slots', $renderer->summary($state));
+    }
+
+    public function testSummaryHandlesPartialOrEmptyPayloadGracefully(): void
+    {
+        $renderer = new IndicatorsRenderer();
+        $state = new DeviceDomainState(true, []);
+
+        self::assertSame('0/3 slots', $renderer->summary($state));
+    }
 }

--- a/tests/Tui/Dashboard/Renderer/NotificationsRendererTest.php
+++ b/tests/Tui/Dashboard/Renderer/NotificationsRendererTest.php
@@ -88,4 +88,37 @@ final class NotificationsRendererTest extends TestCase
 
         self::assertStringNotContainsString("\x1b", $output);
     }
+
+    public function testSummaryReturnsEmptyStringWhenStateHasNoData(): void
+    {
+        $renderer = new NotificationsRenderer();
+        $state = new DeviceDomainState(false, null);
+
+        self::assertSame('', $renderer->summary($state));
+    }
+
+    public function testSummaryReturnsExpectedTextWithFullPayload(): void
+    {
+        $renderer = new NotificationsRenderer();
+        $state = new DeviceDomainState(true, [
+            'queue' => [
+                ['priority' => 'low', 'text' => 'first'],
+                ['priority' => 'high', 'text' => 'second'],
+            ],
+        ]);
+
+        self::assertSame('2 (high)', $renderer->summary($state));
+    }
+
+    public function testSummaryHandlesPartialOrEmptyPayloadGracefully(): void
+    {
+        $renderer = new NotificationsRenderer();
+        $state = new DeviceDomainState(true, [
+            'queue' => [
+                ['text' => 'lonely'],
+            ],
+        ]);
+
+        self::assertSame('1', $renderer->summary($state));
+    }
 }

--- a/tests/Tui/Dashboard/Renderer/TrackersRendererTest.php
+++ b/tests/Tui/Dashboard/Renderer/TrackersRendererTest.php
@@ -86,4 +86,34 @@ final class TrackersRendererTest extends TestCase
 
         self::assertStringNotContainsString("\x1b", $output);
     }
+
+    public function testSummaryReturnsEmptyStringWhenStateHasNoData(): void
+    {
+        $renderer = new TrackersRenderer();
+        $state = new DeviceDomainState(false, null);
+
+        self::assertSame('', $renderer->summary($state));
+    }
+
+    public function testSummaryReturnsExpectedTextWithFullPayload(): void
+    {
+        $renderer = new TrackersRenderer();
+        $state = new DeviceDomainState(true, [
+            'trackers' => [
+                ['label' => 'BTC', 'value' => '42000'],
+                ['label' => 'ETH', 'value' => '3000'],
+                ['label' => 'DOGE', 'value' => '0.15'],
+            ],
+        ]);
+
+        self::assertSame('3 trackers', $renderer->summary($state));
+    }
+
+    public function testSummaryHandlesPartialOrEmptyPayloadGracefully(): void
+    {
+        $renderer = new TrackersRenderer();
+        $state = new DeviceDomainState(true, ['trackers' => []]);
+
+        self::assertSame('0 trackers', $renderer->summary($state));
+    }
 }

--- a/tests/Tui/Dashboard/Renderer/WeatherRendererTest.php
+++ b/tests/Tui/Dashboard/Renderer/WeatherRendererTest.php
@@ -72,4 +72,32 @@ final class WeatherRendererTest extends TestCase
 
         self::assertStringNotContainsString("\x1b", $output);
     }
+
+    public function testSummaryReturnsEmptyStringWhenStateHasNoData(): void
+    {
+        $renderer = new WeatherRenderer();
+        $state = new DeviceDomainState(false, null);
+
+        self::assertSame('', $renderer->summary($state));
+    }
+
+    public function testSummaryReturnsExpectedTextWithFullPayload(): void
+    {
+        $renderer = new WeatherRenderer();
+        $state = new DeviceDomainState(true, [
+            'current' => ['tempC' => 21, 'condition' => 'sunny'],
+        ]);
+
+        self::assertSame('21C sunny', $renderer->summary($state));
+    }
+
+    public function testSummaryHandlesPartialOrEmptyPayloadGracefully(): void
+    {
+        $renderer = new WeatherRenderer();
+        $state = new DeviceDomainState(true, [
+            'current' => ['condition' => 'sunny'],
+        ]);
+
+        self::assertSame('sunny', $renderer->summary($state));
+    }
 }

--- a/tests/Tui/DeviceState/Dev/DevDeviceStateSourceTest.php
+++ b/tests/Tui/DeviceState/Dev/DevDeviceStateSourceTest.php
@@ -176,7 +176,7 @@ final class DevDeviceStateSourceTest extends TestCase
         $snapshot = $source->snapshot();
 
         self::assertSame(
-            ['weather', 'trackers', 'notifications', 'customApps', 'indicators', 'icons'],
+            ['weather', 'trackers', 'notifications', 'indicators', 'icons', 'customApps'],
             array_keys($snapshot),
         );
         self::assertTrue($snapshot['weather']->hasData);

--- a/tests/Tui/Inspector/StateFormatterTest.php
+++ b/tests/Tui/Inspector/StateFormatterTest.php
@@ -41,12 +41,12 @@ final class StateFormatterTest extends TestCase
               active: 2
             [notifications]
               unread: 0
-            [customApps]
-              installed: ["weather","clock"]
             [indicators]
               battery: true
             [icons]
               count: 3
+            [customApps]
+              installed: ["weather","clock"]
             [brightness]
               level: 80
             [settings]

--- a/tests/Tui/Overlay/OverlayMenuTest.php
+++ b/tests/Tui/Overlay/OverlayMenuTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Tui\Overlay;
 
 use App\Tui\Overlay\OverlayMenu;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Widget\TextWidget;
 
 final class OverlayMenuTest extends TestCase
 {
@@ -57,5 +58,31 @@ final class OverlayMenuTest extends TestCase
         $style = $overlay->widget()->getStyle();
         self::assertNotNull($style);
         self::assertTrue($style->getHidden());
+    }
+
+    public function testTitleAndFooterAreRenderedInsideTheOverlay(): void
+    {
+        $overlay = new OverlayMenu(self::SAMPLE_ITEMS);
+
+        $children = $overlay->widget()->all();
+        self::assertGreaterThanOrEqual(3, \count($children));
+
+        $first = $children[0];
+        self::assertInstanceOf(TextWidget::class, $first);
+        self::assertSame('Menu', $first->getText());
+
+        $last = $children[\count($children) - 1];
+        self::assertInstanceOf(TextWidget::class, $last);
+        self::assertStringContainsString('[Esc] close', $last->getText());
+    }
+
+    public function testCustomTitleIsRespected(): void
+    {
+        $overlay = new OverlayMenu(self::SAMPLE_ITEMS, 'Actions');
+
+        $children = $overlay->widget()->all();
+        $first = $children[0];
+        self::assertInstanceOf(TextWidget::class, $first);
+        self::assertSame('Actions', $first->getText());
     }
 }

--- a/tests/Tui/StatusBar/StatusBarWidgetTest.php
+++ b/tests/Tui/StatusBar/StatusBarWidgetTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Tests\Tui\StatusBar;
 
 use App\Tui\StatusBar\StatusBarWidget;
+use App\Tui\Style\Palette;
 use App\Tui\TuiMode;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Style\Color;
 use Symfony\Component\Tui\Style\Direction;
 use Symfony\Component\Tui\Widget\ContainerWidget;
 use Symfony\Component\Tui\Widget\TextWidget;
@@ -32,27 +34,37 @@ final class StatusBarWidgetTest extends TestCase
         self::assertInstanceOf(TextWidget::class, $children[1]);
     }
 
-    public function testDevModeChipTextAndBoldStyle(): void
+    public function testDevModeChipTextAndPaletteColors(): void
     {
-        $statusBar = new StatusBarWidget(TuiMode::Dev);
+        $palette = new Palette();
+        $statusBar = new StatusBarWidget(TuiMode::Dev, $palette);
 
         self::assertSame(' DEV ', $statusBar->chipText());
 
         $chipStyle = $statusBar->chipStyle();
-        self::assertNotNull($chipStyle->getBackground());
-        self::assertNotNull($chipStyle->getColor());
+        $background = $chipStyle->getBackground();
+        $foreground = $chipStyle->getColor();
+        self::assertNotNull($background);
+        self::assertNotNull($foreground);
+        self::assertSame(Color::from($palette->devChipBackground)->toHex(), $background->toHex());
+        self::assertSame(Color::from($palette->devChipForeground)->toHex(), $foreground->toHex());
         self::assertTrue($chipStyle->getBold());
     }
 
-    public function testProdModeChipTextAndBoldStyle(): void
+    public function testProdModeChipTextAndPaletteColors(): void
     {
-        $statusBar = new StatusBarWidget(TuiMode::Prod);
+        $palette = new Palette();
+        $statusBar = new StatusBarWidget(TuiMode::Prod, $palette);
 
         self::assertSame(' PROD ', $statusBar->chipText());
 
         $chipStyle = $statusBar->chipStyle();
-        self::assertNotNull($chipStyle->getBackground());
-        self::assertNotNull($chipStyle->getColor());
+        $background = $chipStyle->getBackground();
+        $foreground = $chipStyle->getColor();
+        self::assertNotNull($background);
+        self::assertNotNull($foreground);
+        self::assertSame(Color::from($palette->prodChipBackground)->toHex(), $background->toHex());
+        self::assertSame(Color::from($palette->prodChipForeground)->toHex(), $foreground->toHex());
         self::assertTrue($chipStyle->getBold());
     }
 
@@ -69,10 +81,20 @@ final class StatusBarWidgetTest extends TestCase
         self::assertNotSame($devBackground->toHex(), $prodBackground->toHex());
     }
 
+    public function testStatusBarUsesDefaultPaletteWhenNoneProvided(): void
+    {
+        $statusBar = new StatusBarWidget(TuiMode::Dev);
+        $defaults = new Palette();
+
+        $background = $statusBar->chipStyle()->getBackground();
+        self::assertNotNull($background);
+        self::assertSame(Color::from($defaults->devChipBackground)->toHex(), $background->toHex());
+    }
+
     public function testSetBaseLineUpdatesRestLineWithoutModeLabel(): void
     {
         $statusBar = new StatusBarWidget(TuiMode::Dev);
-        $statusBar->setBaseLine('TARGET: http://device.local (online)   [Q] quit');
+        $statusBar->setBaseLine('TARGET: http://device.local (online) │ [Q] quit');
 
         $restLine = $statusBar->restLineText();
         self::assertStringContainsString('TARGET:', $restLine);
@@ -80,19 +102,22 @@ final class StatusBarWidgetTest extends TestCase
         self::assertStringNotContainsString('MODE:', $restLine);
     }
 
-    public function testSetUnsavedChangesAppendsIndicatorToRestLine(): void
+    public function testSetUnsavedChangesAppendsIndicatorToRestLineWithBoxDrawingSeparator(): void
     {
         $statusBar = new StatusBarWidget(TuiMode::Prod);
-        $statusBar->setBaseLine('TARGET: http://device.local (online)   [Q] quit');
+        $statusBar->setBaseLine('TARGET: http://device.local (online) │ [Q] quit');
         $statusBar->setUnsavedChanges(true);
 
-        self::assertStringContainsString('UNSAVED CHANGES', $statusBar->restLineText());
+        $restLine = $statusBar->restLineText();
+        self::assertStringContainsString('UNSAVED CHANGES', $restLine);
+        self::assertStringContainsString(' │ UNSAVED CHANGES', $restLine);
+        self::assertStringNotContainsString('   UNSAVED CHANGES', $restLine);
     }
 
     public function testClearingUnsavedChangesRemovesIndicator(): void
     {
         $statusBar = new StatusBarWidget(TuiMode::Prod);
-        $statusBar->setBaseLine('TARGET: http://device.local (online)   [Q] quit');
+        $statusBar->setBaseLine('TARGET: http://device.local (online) │ [Q] quit');
         $statusBar->setUnsavedChanges(true);
         $statusBar->setUnsavedChanges(false);
 

--- a/tests/Tui/Style/PaletteTest.php
+++ b/tests/Tui/Style/PaletteTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Tui\Style;
+
+use App\Tui\Style\Palette;
+use PHPUnit\Framework\TestCase;
+
+final class PaletteTest extends TestCase
+{
+    public function testDefaultTokensMatchSpec(): void
+    {
+        $palette = new Palette();
+
+        self::assertSame('cyan', $palette->headerText);
+        self::assertSame('yellow', $palette->devChipBackground);
+        self::assertSame('black', $palette->devChipForeground);
+        self::assertSame('red', $palette->prodChipBackground);
+        self::assertSame('white', $palette->prodChipForeground);
+        self::assertSame('gray', $palette->borderDim);
+        self::assertSame('green', $palette->borderAccent);
+        self::assertSame('gray', $palette->dimText);
+        self::assertSame('bright_white', $palette->accentText);
+    }
+
+    public function testNamedParameterOverrideSticks(): void
+    {
+        $palette = new Palette(headerText: 'magenta');
+
+        self::assertSame('magenta', $palette->headerText);
+        self::assertSame('yellow', $palette->devChipBackground);
+    }
+}


### PR DESCRIPTION
## Summary

Final visual pass of the TUI dashboard: a shared `Palette` of color tokens drives all widgets (cyan header text, yellow/red mode chips, accent/dim borders for [on]/[off] blocks, full border around the selected block). Per-domain collapsed summary lines surface key data next to each title, the status bar uses a consistent ` │ ` separator that fits 80 columns, and the overlay menu gets a title and `[Esc] close` footer. `AppDomain` cases are reordered to the canonical sequence.

All styling uses the public `symfony/tui` `Style` API only.

## Ticket

Closes #46